### PR TITLE
Adding ability to override MachineName on Raygun

### DIFF
--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -59,12 +59,13 @@ namespace Serilog
             IEnumerable<string> ignoredFormFieldNames = null,
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
-            string userInfoProperty = null)
+            string userInfoProperty = null,
+            string machineNameProperty = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             return loggerConfiguration.Sink(
-                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty),
+                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty, machineNameProperty),
                 restrictedToMinimumLevel);
         }
 


### PR DESCRIPTION
When working with Mobile Devices, machine name was often coming in as localhost.  I realized that it is using the user specified name, in our context that was not helpful.  We wanted to override the machine name to populate it with the device type.  Raygun pointed us in the direction of the SendingMessage event, and suggested connecting to it and overriding the machine there.

Upon further review I realized we were using Serilog with the Raygun Sink and that it was spinning up its own Raygun client, so I could not add a listener to the event handler.  They then suggested submitting a pull request to this repository to allow passing in the machineName, and if passed in to then add a listener to the SendingMessage event.  I would love to see this merged in as soon as possible if it looks ok to the maintainers.  Thanks.