### PR TITLE
Adding on before send action

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("ra
 
 `default: null`
 
-The field allows users to manipulate the crash report payload to be sent to Raygun.
-By default it is `null`, so you don't need to set it in the constructor. If the field is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it gets called just before the crash report payload gets serialized and sent to Raygun.
+This action allows you to manipulate the crash report payloads that get sent to Raygun.
+By default it is `null`, so you don't need to set it in the constructor. If the action is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it gets called just before the crash report payload gets serialized and sent to Raygun.
 The arguments to the action are of type `Struct OnBeforeSendArguments`; they are passed to the action when it is called and contain references to the following objects passed by the Raygun client object:
 ```csharp
-//Abstracted away version of the struct to just show the fields
+// Abstracted away version of the struct to just show the properties
 struct OnBeforeSendArguments
 {
     System.Exception Exception;
@@ -188,8 +188,8 @@ struct OnBeforeSendArguments
 }
 ```
 
-The provided action can read and/or modify their fields accordingly to produce the desired effect.
-For example, one can change the `MachineName` field in the `Details` of the `RaygunMessage` as follows:
+The provided action can read and/or modify their properties accordingly to produce the desired effect.
+For example, one can change the `MachineName` property in the `Details` of the `RaygunMessage` as follows:
 
 ```csharp
 Log.Logger = new LoggerConfiguration()

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Log.Logger = new LoggerConfiguration()
       "CustomGroupKeyProperty",
       "CustomTagsProperty",
       "CustomUserInfoProperty",
-      onBeforeSendParameters => { /*OnBeforeSend: Action<OnBeforeSendParameters>*/ })
+      onBeforeSendArguments => { /*OnBeforeSend: Action<onBeforeSendArguments>*/ })
     .CreateLogger();
 ```
 
@@ -192,14 +192,14 @@ The provided action can read and/or modify their fields accordingly to produce t
 For example, one can change the `MachineName` field in the `Details` of the `RaygunMessage` as follows:
 
 ```csharp
-var raygunSink = new RaygunSink(
-    formatProvider: null,
-    applicationKey: "",
-    onBeforeSend: arguments =>
-    {
-        raygunMessage = arguments.RaygunMessage;
-        arguments.RaygunMessage.Details.MachineName = "MyMachine";
-    }
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun(
+        applicationKey: "",
+        onBeforeSend: arguments => { 
+            arguments.RaygunMessage.Details.MachineName = "MyMachine";
+        })
+    .CreateLogger();
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # serilog-sinks-raygun
 
-[![Build status](https://ci.appveyor.com/api/projects/status/bol0v48ujapxobym/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-raygun/branch/master)
-
 A Serilog sink that writes events to Raygun
 
 ## Usage
@@ -29,7 +27,8 @@ Log.Logger = new LoggerConfiguration()
       new[] { "ignoreField1", "ignoreField2" },
       "CustomGroupKeyProperty",
       "CustomTagsProperty",
-      "CustomUserInfoProperty")
+      "CustomUserInfoProperty",
+      onBeforeSendParameters => { /*OnBeforeSend: Action<OnBeforeSendParameters>*/ })
     .CreateLogger();
 ```
 
@@ -171,6 +170,44 @@ var userInfo = new RaygunIdentifierMessage("12345")
 
 Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("random error"), "other information");
 ```
+
+### onBeforeSend
+`type: Action<OnBeforeSendParameters>`
+
+`default: null`
+
+The field allows users to manipulate the data to be sent to Raygun.
+This is a function that is executed by the raygun client's `CustomGroupingKey` event, and happens at the end of the `OnCustomGroupingKey` event callback.
+By default it is `null`, so you don't need to set it in the constructor.
+If the field is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it is executed at the described time.
+The arguments to the action are of type `OnBeforeSendParameters`, which is a C# `struct` and thus will be allocated directly on the call-stack for efficiency.
+This means, the `struct` object will only be available to the `onBeforeSend` Action and will be automatically deallocated after it returns.
+The arguments are passed automatically to the action when it is called and contain references to the following objects passed by the Raygun client object:
+```csharp
+//Abstracted away version of the struct to just show the fields
+struct OnBeforeSendParameters
+{
+    System.Exception Exception;
+    Mindscape.Raygun4Net.Messages.RaygunMessage RaygunMessage;
+}
+```
+
+The provided action can read and/or modify their fields accordingly to produce the desired effect.
+For example, one can change the `MachineName` field in the `Details` of the `RaygunMessage` as follows:
+
+```csharp
+var raygunSink = new RaygunSink(
+    formatProvider: null,
+    applicationKey: "",
+    onBeforeSend: parameters =>
+    {
+        raygunMessage = parameters.RaygunMessage;
+        parameters.RaygunMessage.Details.MachineName = "MyMachine";
+    }
+);
+```
+
+
 ## Enrich with HTTP request and response data
 
 _Note: This is only valid for .NET Standard 2.0 and above projects. In full framework ASP.NET applications the HTTP request and response are available to Raygun4Net through the `HttpContext.Current` accessor.

--- a/README.md
+++ b/README.md
@@ -176,16 +176,12 @@ Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("ra
 
 `default: null`
 
-The field allows users to manipulate the data to be sent to Raygun.
-This is a function that is executed by the raygun client's `CustomGroupingKey` event, and happens at the end of the `OnCustomGroupingKey` event callback.
-By default it is `null`, so you don't need to set it in the constructor.
-If the field is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it is executed at the described time.
-The arguments to the action are of type `OnBeforeSendParameters`, which is a C# `struct` and thus will be allocated directly on the call-stack for efficiency.
-This means, the `struct` object will only be available to the `onBeforeSend` Action and will be automatically deallocated after it returns.
-The arguments are passed automatically to the action when it is called and contain references to the following objects passed by the Raygun client object:
+The field allows users to manipulate the crash report payload to be sent to Raygun.
+By default it is `null`, so you don't need to set it in the constructor. If the field is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it gets called just before the crash report payload gets serialized and sent to Raygun.
+The arguments to the action are of type `Struct OnBeforeSendArguments`; they are passed to the action when it is called and contain references to the following objects passed by the Raygun client object:
 ```csharp
 //Abstracted away version of the struct to just show the fields
-struct OnBeforeSendParameters
+struct OnBeforeSendArguments
 {
     System.Exception Exception;
     Mindscape.Raygun4Net.Messages.RaygunMessage RaygunMessage;
@@ -199,10 +195,10 @@ For example, one can change the `MachineName` field in the `Details` of the `Ray
 var raygunSink = new RaygunSink(
     formatProvider: null,
     applicationKey: "",
-    onBeforeSend: parameters =>
+    onBeforeSend: arguments =>
     {
-        raygunMessage = parameters.RaygunMessage;
-        parameters.RaygunMessage.Details.MachineName = "MyMachine";
+        raygunMessage = arguments.RaygunMessage;
+        arguments.RaygunMessage.Details.MachineName = "MyMachine";
     }
 );
 ```

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -45,6 +45,7 @@ namespace Serilog
         /// <param name="groupKeyProperty">The property containing the custom group key for the Raygun message.</param>
         /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
         /// <param name="userInfoProperty">The property containing the RaygunIdentifierMessage structure used to populate user details.</param>
+        /// <param name="onBeforeSend">The action to be executed right before a logging message is sent to Raygun</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Raygun(
@@ -59,12 +60,13 @@ namespace Serilog
             IEnumerable<string> ignoredFormFieldNames = null,
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
-            string userInfoProperty = null)
+            string userInfoProperty = null,
+            Action<OnBeforeSendArguments> onBeforeSend = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             return loggerConfiguration.Sink(
-                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty),
+                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty, onBeforeSend),
                 restrictedToMinimumLevel);
         }
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendArguments.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendArguments.cs
@@ -9,7 +9,7 @@ using Mindscape.Raygun4Net.Messages;
 
 namespace Serilog.Sinks.Raygun
 {
-    public readonly struct OnBeforeSendParameters
+    public readonly struct OnBeforeSendArguments
     {
         private readonly Exception _exception;
         private readonly RaygunMessage _raygunMessage;
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Raygun
         public Exception Exception => _exception;
         public RaygunMessage RaygunMessage => _raygunMessage;
 
-        public OnBeforeSendParameters(Exception exception, RaygunMessage raygunMessage)
+        public OnBeforeSendArguments(Exception exception, RaygunMessage raygunMessage)
         {
             _exception = exception;
             _raygunMessage = raygunMessage;

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Raygun
+{
+    public struct OnBeforeSendParameters
+    {
+        private readonly LogEvent _logEvent;
+        private readonly List<string> _tags;
+        private readonly Dictionary<string, LogEventPropertyValue> _properties;
+
+        public LogEvent LogEvent => _logEvent;
+        public List<string> Tags => _tags;
+        public Dictionary<string, LogEventPropertyValue> Properties => _properties;
+
+        public OnBeforeSendParameters(LogEvent logEvent, List<string> tags, Dictionary<string, LogEventPropertyValue> properties)
+        {
+            _logEvent = logEvent;
+            _tags = tags;
+            _properties = properties;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
@@ -3,7 +3,7 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Raygun
 {
-    public struct OnBeforeSendParameters
+    public readonly struct OnBeforeSendParameters
     {
         private readonly LogEvent _logEvent;
         private readonly List<string> _tags;

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendParameters.cs
@@ -1,23 +1,26 @@
-﻿using System.Collections.Generic;
-using Serilog.Events;
+﻿using System;
+using Mindscape.Raygun4Net;
+#if NETSTANDARD2_0
+using Mindscape.Raygun4Net.AspNetCore;
+#else
+using Mindscape.Raygun4Net.Builders;
+using Mindscape.Raygun4Net.Messages;
+#endif
 
 namespace Serilog.Sinks.Raygun
 {
     public readonly struct OnBeforeSendParameters
     {
-        private readonly LogEvent _logEvent;
-        private readonly List<string> _tags;
-        private readonly Dictionary<string, LogEventPropertyValue> _properties;
+        private readonly Exception _exception;
+        private readonly RaygunMessage _raygunMessage;
 
-        public LogEvent LogEvent => _logEvent;
-        public List<string> Tags => _tags;
-        public Dictionary<string, LogEventPropertyValue> Properties => _properties;
+        public Exception Exception => _exception;
+        public RaygunMessage RaygunMessage => _raygunMessage;
 
-        public OnBeforeSendParameters(LogEvent logEvent, List<string> tags, Dictionary<string, LogEventPropertyValue> properties)
+        public OnBeforeSendParameters(Exception exception, RaygunMessage raygunMessage)
         {
-            _logEvent = logEvent;
-            _tags = tags;
-            _properties = properties;
+            _exception = exception;
+            _raygunMessage = raygunMessage;
         }
     }
 }

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.Raygun
         private readonly string _tagsProperty;
         private readonly string _userInfoProperty;
         private readonly RaygunClient _client;
-        private readonly Action<OnBeforeSendParameters> _onBeforeSend;
+        private readonly Action<OnBeforeSendArguments> _onBeforeSend;
 
         /// <summary>
         /// Construct a sink that saves errors to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
@@ -72,7 +72,7 @@ namespace Serilog.Sinks.Raygun
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
             string userInfoProperty = null,
-            Action<OnBeforeSendParameters> onBeforeSend = null)
+            Action<OnBeforeSendArguments> onBeforeSend = null)
         {
             _formatProvider = formatProvider;
             _userNameProperty = userNameProperty;
@@ -254,8 +254,8 @@ namespace Serilog.Sinks.Raygun
             // Call onBeforeSend
             if (_onBeforeSend != null)
             {
-                var onBeforeSendParameters = new OnBeforeSendParameters(e?.Exception, e?.Message);
-                _onBeforeSend(onBeforeSendParameters);
+                var onBeforeSendArguments = new OnBeforeSendArguments(e?.Exception, e?.Message);
+                _onBeforeSend(onBeforeSendArguments);
             }
         }
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -126,13 +126,6 @@ namespace Serilog.Sinks.Raygun
                 properties.Remove(_tagsProperty);
             }
 
-            // Call onBeforeSend
-            if (_onBeforeSend != null)
-            {
-                var onBeforeSendParameters = new OnBeforeSendParameters(logEvent, tags, properties);
-                _onBeforeSend(onBeforeSendParameters);
-            }
-            
             // Decide what exception object to send
             var exception = logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace());
 
@@ -256,6 +249,13 @@ namespace Serilog.Sinks.Raygun
                         .Select(pv => new { Name = pv.Key, Value = RaygunPropertyFormatter.Simplify(pv.Value) })
                         .ToDictionary(a => a.Name, b => b.Value);
                 }
+            }
+            
+            // Call onBeforeSend
+            if (_onBeforeSend != null)
+            {
+                var onBeforeSendParameters = new OnBeforeSendParameters(e?.Exception, e?.Message);
+                _onBeforeSend(onBeforeSendParameters);
             }
         }
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -46,6 +46,7 @@ namespace Serilog.Sinks.Raygun
         private readonly string _tagsProperty;
         private readonly string _userInfoProperty;
         private readonly RaygunClient _client;
+        private readonly Action<OnBeforeSendParameters> _onBeforeSend;
 
         /// <summary>
         /// Construct a sink that saves errors to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
@@ -60,6 +61,7 @@ namespace Serilog.Sinks.Raygun
         /// <param name="groupKeyProperty">The property containing the custom group key for the Raygun message.</param>
         /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
         /// <param name="userInfoProperty">The property where a RaygunIdentifierMessage with more user information can optionally be provided.</param>
+        /// <param name="onBeforeSend">The action to be executed right before a logging message is sent to Raygun</param>
         public RaygunSink(IFormatProvider formatProvider,
             string applicationKey,
             IEnumerable<Type> wrapperExceptions = null,
@@ -69,7 +71,8 @@ namespace Serilog.Sinks.Raygun
             IEnumerable<string> ignoredFormFieldNames = null,
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
-            string userInfoProperty = null)
+            string userInfoProperty = null,
+            Action<OnBeforeSendParameters> onBeforeSend = null)
         {
             _formatProvider = formatProvider;
             _userNameProperty = userNameProperty;
@@ -78,6 +81,8 @@ namespace Serilog.Sinks.Raygun
             _groupKeyProperty = groupKeyProperty;
             _tagsProperty = tagsProperty;
             _userInfoProperty = userInfoProperty;
+            _onBeforeSend = onBeforeSend;
+            
 
 #if NETSTANDARD2_0
             _client = new RaygunClient(applicationKey);
@@ -121,14 +126,24 @@ namespace Serilog.Sinks.Raygun
                 properties.Remove(_tagsProperty);
             }
 
+            // Call onBeforeSend
+            if (_onBeforeSend != null)
+            {
+                var onBeforeSendParameters = new OnBeforeSendParameters(logEvent, tags, properties);
+                _onBeforeSend(onBeforeSendParameters);
+            }
+            
+            // Decide what exception object to send
+            var exception = logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace());
+
             // Submit
             if (logEvent.Level == LogEventLevel.Fatal)
             {
-                _client.Send(logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace()), tags, properties);
+                _client.Send(exception, tags, properties);
             }
             else
             {
-                _client.SendInBackground(logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace()), tags, properties);
+                _client.SendInBackground(exception, tags, properties);
             }
         }
 

--- a/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
+++ b/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
 
 		<IsPackable>false</IsPackable>
+
+		<TargetFrameworks>netstandard2.0;net46;net461</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -11,6 +11,32 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
     public class OnBeforeSendActionTests
     {
         [Test]
+        public void TestCreatingAndChangingOnBeforeSendParameters()
+        {
+            var logEvent = new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Debug,
+                new Exception("Test Exception"),
+                new MessageTemplate(new TextToken[] { }),
+                new LogEventProperty[] { }
+            );
+
+            var tags = new List<string>();
+            var properties = new Dictionary<string, LogEventPropertyValue>();
+            
+            var onBeforeSendParameters = new OnBeforeSendParameters(
+                logEvent: logEvent,
+                tags: tags,
+                properties: properties
+            );
+            
+            Assert.IsNotNull(onBeforeSendParameters);
+            
+            onBeforeSendParameters.Tags.Add("testTag");
+            Assert.IsTrue(onBeforeSendParameters.Tags.Contains("testTag"));
+        }
+        
+        [Test]
         public void TestCreatingRaygunSinkWithOnBeforeSendAction()
         {
             var raygunSink = new RaygunSink(

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -2,6 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mindscape.Raygun4Net;
+#if NETSTANDARD2_0
+using Mindscape.Raygun4Net.AspNetCore;
+#else
+using Mindscape.Raygun4Net.Builders;
+using Mindscape.Raygun4Net.Messages;
+#endif
 using NUnit.Framework;
 using Serilog.Events;
 using Serilog.Parsing;
@@ -12,20 +18,20 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
     public class OnBeforeSendActionTests
     {
         [Test]
-        public void TestCreatingAndChangingOnBeforeSendParameters()
+        public void TestCreatingAndChangingOnBeforeSendArguments()
         {
             var exception = new Exception();
             var raygunMessage = new RaygunMessage();
             
-            var onBeforeSendParameters = new OnBeforeSendArguments(
+            var onBeforeSendArguments = new OnBeforeSendArguments(
                 exception: exception,
                 raygunMessage: raygunMessage
             );
             
-            Assert.IsNotNull(onBeforeSendParameters);
+            Assert.IsNotNull(onBeforeSendArguments);
 
-            onBeforeSendParameters.RaygunMessage.Details.MachineName = "TestMachineName";
-            Assert.AreEqual("TestMachineName", onBeforeSendParameters.RaygunMessage.Details.MachineName);
+            onBeforeSendArguments.RaygunMessage.Details.MachineName = "TestMachineName";
+            Assert.AreEqual("TestMachineName", onBeforeSendArguments.RaygunMessage.Details.MachineName);
         }
         
         [Test]
@@ -38,6 +44,20 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
                 );
             
             Assert.NotNull(raygunSink);
+        }
+        
+        [Test]
+        public void TestCreatingLoggerConfigurationWithOnBeforeSendActionViaExtensionMethod()
+        {
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Raygun(
+                    applicationKey: "",
+                    onBeforeSend: arguments => { }
+                    )
+                .CreateLogger();
+        
+            Assert.NotNull(logger);
         }
 
         [Test]

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
             var exception = new Exception();
             var raygunMessage = new RaygunMessage();
             
-            var onBeforeSendParameters = new OnBeforeSendParameters(
+            var onBeforeSendParameters = new OnBeforeSendArguments(
                 exception: exception,
                 raygunMessage: raygunMessage
             );
@@ -34,7 +34,7 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
             var raygunSink = new RaygunSink(
                 formatProvider: null,
                 applicationKey: "",
-                onBeforeSend: parameters => { }
+                onBeforeSend: arguments => { }
                 );
             
             Assert.NotNull(raygunSink);
@@ -47,7 +47,7 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
             var raygunSink = new RaygunSink(
                 formatProvider: null,
                 applicationKey: "",
-                onBeforeSend: parameters =>
+                onBeforeSend: arguments =>
                 {
                     onBeforeSendFlag = true;
                 }
@@ -80,10 +80,10 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
             var raygunSink = new RaygunSink(
                 formatProvider: null,
                 applicationKey: "",
-                onBeforeSend: parameters =>
+                onBeforeSend: arguments =>
                 {
-                    raygunMessage = parameters.RaygunMessage;
-                    parameters.RaygunMessage.Details.MachineName = "TestMachineName";
+                    raygunMessage = arguments.RaygunMessage;
+                    arguments.RaygunMessage.Details.MachineName = "TestMachineName";
                 }
             );
             

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+
+namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
+{
+    [TestFixture]
+    public class OnBeforeSendActionTests
+    {
+        [Test]
+        public void TestCreatingRaygunSinkWithOnBeforeSendAction()
+        {
+            var raygunSink = new RaygunSink(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    parameters => { }
+                );
+            
+            Assert.NotNull(raygunSink);
+        }
+        
+    }
+}

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -1,4 +1,9 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Parsing;
 
 namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
 {
@@ -9,21 +14,38 @@ namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
         public void TestCreatingRaygunSinkWithOnBeforeSendAction()
         {
             var raygunSink = new RaygunSink(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    parameters => { }
+                formatProvider: null,
+                applicationKey: "",
+                onBeforeSend: parameters => { }
                 );
             
             Assert.NotNull(raygunSink);
         }
-        
+
+        [Test]
+        public void TestOnBeforeSendActionCalledAfterEmit()
+        {
+            var onBeforeSendFlag = false;
+            var raygunSink = new RaygunSink(
+                formatProvider: null,
+                applicationKey: "",
+                onBeforeSend: parameters =>
+                {
+                    onBeforeSendFlag = true;
+                }
+            );
+            
+            Assert.NotNull(raygunSink);
+            Assert.IsFalse(onBeforeSendFlag);
+            
+            raygunSink.Emit(new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Information,
+                null,
+                new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()),
+                new List<LogEventProperty>()));
+            
+            Assert.IsTrue(onBeforeSendFlag);
+        }
     }
 }


### PR DESCRIPTION
This PR enables the execution of user function (Action) right before a message is sent to Raygun. The function is passed as an argument to the RaygunSink constructor (null default). It is executed by the raygun client's `CustomGroupingKey` event, and happens at the end of the `OnCustomGroupingKey` event callback. The new `onBeforeSend` callback takes a single input: a struct instance (call-stack allocated) of type `OnBeforeSendParameters` that future-proofs adding new fields to it. Currently, it holds a pointer to the `Exception` being handled and the `RaygunMessage` to be sent to Raygun.

Two new test files have been added with test cases around the new behavior and the new struct