### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Install the Serilog (if not included already) and Serilog.Sinks.Raygun package i
 ------
 
 ## Step 2 - Initialization
-There are two main options for initializing the Raygun serilog sink. Which option is best to use depends on the application. 
+There are two recommended options for initializing the Raygun serilog sink. Which option is best to use depends on the application. 
 
 ### Option 1 - Using logger configuration
 
-You can initialize Raygun's Serilog sink through a Logger Configuration. This should be done inside of the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
+You can initialize Raygun's Serilog Sink through a Logger Configuration. This should be done inside of the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
 **Minimum setup example:**
 
 ```cs
@@ -55,7 +55,7 @@ Log.Logger = new LoggerConfiguration()
 ------
 
 ### Option 2 - Using the JSON configuration file
-You can initialize Raygun's Serilog sink inside a Serilog JSON configuration file using the following examples.
+You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration file using the following examples.
 **Minimum setup example:**
 
 ```json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ There are two recommended options for initializing the Raygun Serilog Sink. Whic
 ### Option 1 - Using logger configuration
 
 You can initialize Raygun's Serilog Sink through a Logger Configuration. This should be done inside of the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
+
 **Minimum setup example:**
 
 ```cs
@@ -56,6 +57,7 @@ Log.Logger = new LoggerConfiguration()
 
 ### Option 2 - Using the JSON configuration file
 You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration file using the following examples.
+
 **Minimum setup example:**
 
 ```json
@@ -389,4 +391,4 @@ Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw 
 
 `default: true`
 
-Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible)
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible)  in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,23 @@ Install the Serilog (if not included already) and Serilog.Sinks.Raygun package i
 
 ------
 
-## Step 2 - Add logger configuration
+## Step 2 - Initialization
+There are two main options for initializing the Raygun serilog sink. Which option is best to use depends on the application. 
 
-Setup the logger configuration by passing in your API key. You can do this inside of Program.Main(), Global.asax, Application_Start, or how ever your application is set up with the main, start up running method of your application.
+### Option 1 - Using logger configuration
+
+You can initialize Raygun's Serilog sink through a Logger Configuration. This should be done inside of the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
+**Minimum setup example:**
 
 ```cs
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun("paste_your_api_key_here")
+    .CreateLogger();
+```
+
+**Example setup with optional properties:**
+```csharp
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Verbose()
     .WriteTo.Raygun("paste_your_api_key_here",
@@ -40,13 +52,31 @@ Log.Logger = new LoggerConfiguration()
       onBeforeSendArguments => { /*OnBeforeSend: Action<onBeforeSendArguments>*/ })
     .CreateLogger();
 ```
-
 ------
 
-## Step 3 - Configure the JSON configuration file
+### Option 2 - Using the JSON configuration file
+You can initialize Raygun's Serilog sink inside a Serilog JSON configuration file using the following examples.
+**Minimum setup example:**
 
-When configuring using a JSON configuration file use the following example -
+```json
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Raygun"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Raygun",
+        "Args": {
+          "applicationKey": "paste_your_api_key_here"
+		}
+      }
+    ]
+  }  
+}
+```
 
+**Example setup with optional properties:**
 ```json
 {
   "Serilog": {
@@ -359,4 +389,4 @@ Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw 
 
 `default: true`
 
-Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration fil
 }
 ```
 
-### Properties
+----
+
+## Configuration Properties
 
 **applicationKey**
 
@@ -391,4 +393,4 @@ Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw 
 
 `default: true`
 
-Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible)  in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the Serilog (if not included already) and Serilog.Sinks.Raygun package i
 ------
 
 ## Step 2 - Initialization
-There are two recommended options for initializing the Raygun serilog sink. Which option is best to use depends on the application. 
+There are two recommended options for initializing the Raygun Serilog Sink. Which option is best to use depends on the application. 
 
 ### Option 1 - Using logger configuration
 

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -14,7 +14,7 @@
     <PackageTags>serilog sink raygun</PackageTags>
     <Copyright>Copyright © Serilog Contributors 2017-2020</Copyright>
     <Description>Serilog event sink that writes to the Raygun service.</Description>
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>5.3.1</VersionPrefix>
     <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION

This PR implements readme suggestions made by @QuantumNightmare
**Suggestions:**
- Step 2: I think "how ever" should be 1 word, and I don't think there should be a comma after "main".
- The ".writeTo.Raygun" code in step 2 and all of step 3 are actually two different ways to do the same thing. The setup code can actual be different between .NET Framework vs .NET Core or a web app vs desktop app or you want to configure in code vs configure in the config file. Lots of permutations there so may need to have a think about how to suit different customers situations and make that clear.
- A lot of the arguments listed in step 2 and 3 could be confusing and are optional, so I think we want to dial that back to the minimum required. In the instructions, it looks like it's all required, and so people will probably copy/paste it all. Most of those are dummy example values intended to be substituted e.g. "CustomUserNameProperty", but only if that feature is intended to be used.