### PR TITLE
Allow Serilog Sink to use Custom Client Provider to feature match asp.net core

### DIFF
--- a/Raygun.Serilog.sln
+++ b/Raygun.Serilog.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun", "src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj", "{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Raygun", "src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj", "{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.Tests", "test\Serilog.Sinks.Raygun.Tests\Serilog.Sinks.Raygun.Tests.csproj", "{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Raygun.Tests", "test\Serilog.Sinks.Raygun.Tests\Serilog.Sinks.Raygun.Tests.csproj", "{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.SampleConsoleApp", "sampleApps\Serilog.Sinks.Raygun.SampleConsoleApp\Serilog.Sinks.Raygun.SampleConsoleApp.csproj", "{84BCC6CF-66EB-4965-9566-F3F314EDA311}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Raygun.SampleConsoleApp", "sampleApps\Serilog.Sinks.Raygun.SampleConsoleApp\Serilog.Sinks.Raygun.SampleConsoleApp.csproj", "{84BCC6CF-66EB-4965-9566-F3F314EDA311}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Raygun.Serilog.sln.DotSettings
+++ b/Raygun.Serilog.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">240</s:Int64></wpf:ResourceDictionary>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
@@ -43,3 +43,4 @@ catch (Exception e)
 Thread.Sleep(1000); 
 
 Console.Out.WriteLine("All done! Please check your Raygun App to ensure the two logged exceptions appear");
+Console.ReadKey();

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
@@ -43,4 +43,3 @@ catch (Exception e)
 Thread.Sleep(1000); 
 
 Console.Out.WriteLine("All done! Please check your Raygun App to ensure the two logged exceptions appear");
-Console.ReadKey();

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Serilog.Sinks.Raygun.SampleConsoleApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Serilog.Sinks.Raygun.SampleConsoleApp.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Serilog" Version="2.12.0" />
+      <PackageReference Include="Serilog" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -19,7 +19,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.Raygun;
 
-#if NET
+#if NET || NETSTANDARD
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
 #endif
@@ -64,7 +64,7 @@ namespace Serilog
             string tagsProperty = "Tags",
             string userInfoProperty = null,
             Action<OnBeforeSendArguments> onBeforeSend = null
-#if NET
+#if NET || NETSTANDARD
             , RaygunSettings settings = null
             , IRaygunAspNetCoreClientProvider raygunAspNetCoreClientProvider = null
 #endif
@@ -72,7 +72,7 @@ namespace Serilog
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
-#if NET
+#if NET || NETSTANDARD
             return loggerConfiguration.Sink(
                 new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty, onBeforeSend, settings, raygunAspNetCoreClientProvider),
                 restrictedToMinimumLevel);
@@ -83,7 +83,7 @@ namespace Serilog
 #endif
         }
 
-#if NET
+#if NET || NETSTANDARD
         /// <summary>
         /// Add the <see cref="RaygunClientHttpEnricher"/> to the enrichment configuration.
         /// </summary>

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -14,10 +14,12 @@
 
 using System;
 using System.Collections.Generic;
+using Mindscape.Raygun4Net;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.Raygun;
-#if NETSTANDARD2_0
+
+#if NET
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
 #endif
@@ -61,16 +63,27 @@ namespace Serilog
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
             string userInfoProperty = null,
-            Action<OnBeforeSendArguments> onBeforeSend = null)
+            Action<OnBeforeSendArguments> onBeforeSend = null
+#if NET
+            , RaygunSettings settings = null
+            , IRaygunAspNetCoreClientProvider raygunAspNetCoreClientProvider = null
+#endif
+            )
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
+#if NET
+            return loggerConfiguration.Sink(
+                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty, onBeforeSend, settings, raygunAspNetCoreClientProvider),
+                restrictedToMinimumLevel);
+#else
             return loggerConfiguration.Sink(
                 new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty, onBeforeSend),
                 restrictedToMinimumLevel);
+#endif
         }
 
-#if NETSTANDARD2_0
+#if NET
         /// <summary>
         /// Add the <see cref="RaygunClientHttpEnricher"/> to the enrichment configuration.
         /// </summary>

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,41 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46;net461</TargetFrameworks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Michiel van Oudheusden</Authors>
-    <Company>Serilog</Company>
-    <Product>Serilog.Sinks.Raygun</Product>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
-    <PackageIcon>serilog-sink-nuget.png</PackageIcon>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
-    <PackageTags>serilog sink raygun</PackageTags>
-    <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
-    <Description>Serilog event sink that writes to the Raygun service.</Description>
-    <VersionPrefix>5.3.3</VersionPrefix>
-    <RootNamespace>Serilog</RootNamespace>
-  </PropertyGroup>
+    <PropertyGroup>
+        <!--    <TargetFramework>net462</TargetFramework>-->
+        <TargetFrameworks>net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <OutputType>Library</OutputType>
+        
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Authors>Raygun, Michiel van Oudheusden</Authors>
+        <Company>Serilog</Company>
+        <Product>Serilog.Sinks.Raygun</Product>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
+        <PackageIcon>serilog-sink-nuget.png</PackageIcon>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
+        <PackageTags>serilog sink raygun</PackageTags>
+        <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
+        <Description>Serilog event sink that writes to the Raygun service.</Description>
+        <VersionPrefix>5.3.3</VersionPrefix>
+        <RootNamespace>Serilog</RootNamespace>
+    </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.3" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Mindscape.Raygun4Net" Version="6.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="mindscape.Raygun4Net.AspNetCore" Version="6.6.5" />
-  </ItemGroup>
-
-  <ItemGroup>	
-    <PackageReference Include="Serilog" Version="2.10.0" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+        <PackageReference Include="Mindscape.Raygun4Net" Version="7.0.1"/>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
+    </ItemGroup>
 
     <ItemGroup>
-    <None Include="..\..\serilog-sink-nuget.png" Pack="true" PackagePath="\"/>
-  </ItemGroup>  
+<!--        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>-->
+        <PackageReference Include="Serilog" Version="3.0.0"/>
+    </ItemGroup>
 
+    <ItemGroup>
+        <None Include="..\..\serilog-sink-nuget.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+    
 </Project>

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -22,7 +22,9 @@
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or 
+                          '$(TargetFramework)' == 'net5.0' or 
+                          '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>
     </ItemGroup>
 

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!--    <TargetFramework>net462</TargetFramework>-->
         <TargetFrameworks>net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <OutputType>Library</OutputType>
@@ -15,7 +14,7 @@
         <PackageIcon>serilog-sink-nuget.png</PackageIcon>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
-        <PackageTags>serilog sink raygun</PackageTags>
+        <PackageTags>serilog;sink;raygun;crash;exception-handling;exception-reporting;exception-handler;unhandled-exceptions;debugging;debug;bug;bugs;exceptions;error;errors;crash-reporting;aspnet-core</PackageTags>
         <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <VersionPrefix>5.3.3</VersionPrefix>
@@ -34,7 +33,6 @@
     </ItemGroup>
 
     <ItemGroup>
-<!--        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>-->
         <PackageReference Include="Serilog" Version="3.0.0"/>
     </ItemGroup>
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendArguments.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/OnBeforeSendArguments.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+
+#if (NET || NETSTANDARD2_0_OR_GREATER) && !NETFRAMEWORK
 using Mindscape.Raygun4Net;
-#if NETSTANDARD2_0
-using Mindscape.Raygun4Net.AspNetCore;
 #else
-using Mindscape.Raygun4Net.Builders;
 using Mindscape.Raygun4Net.Messages;
 #endif
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientHttpEnricher.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientHttpEnricher.cs
@@ -1,5 +1,5 @@
 ﻿
-#if NET
+#if NET || NETSTANDARD
 using System;
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net;

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientHttpEnricher.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientHttpEnricher.cs
@@ -1,4 +1,5 @@
-﻿#if NETSTANDARD2_0
+﻿
+#if NET
 using System;
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net;

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -24,9 +24,7 @@ using Mindscape.Raygun4Net;
 #if NET || NETSTANDARD
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
-
 #else
-using Mindscape.Raygun4Net;
 using Mindscape.Raygun4Net.Builders;
 using Mindscape.Raygun4Net.Messages;
 #endif
@@ -49,7 +47,6 @@ namespace Serilog.Sinks.Raygun
         private readonly string _groupKeyProperty;
         private readonly string _tagsProperty;
         private readonly string _userInfoProperty;
-        //private readonly RaygunClient _client;
         private readonly Action<OnBeforeSendArguments> _onBeforeSend;
         private readonly string _applicationKey;
         private readonly IEnumerable<Type> _wrapperExceptions;
@@ -224,8 +221,7 @@ namespace Serilog.Sinks.Raygun
                         {
                             ClassName = properties[LogMessageTemplateProperty].AsString(),
                             Message = properties[RenderedLogMessageProperty].AsString(),
-                            StackTrace =
-                                RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
+                            StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
                         };
                     }
 
@@ -291,8 +287,7 @@ namespace Serilog.Sinks.Raygun
 #if NET || NETSTANDARD
                     // Add Http request/response messages if present and not already set
                     if (details.Request == null &&
-                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunRequestMessagePropertyName,
-                            out var requestMessageProperty) &&
+                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunRequestMessagePropertyName, out var requestMessageProperty) &&
                         requestMessageProperty is StructureValue requestMessageValue)
                     {
                         details.Request = BuildRequestMessageFromStructureValue(requestMessageValue);
@@ -300,8 +295,7 @@ namespace Serilog.Sinks.Raygun
                     }
 
                     if (details.Response == null &&
-                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunResponseMessagePropertyName,
-                            out var responseMessageProperty) &&
+                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunResponseMessagePropertyName, out var responseMessageProperty) &&
                         responseMessageProperty is StructureValue responseMessageValue)
                     {
                         details.Response = BuildResponseMessageFromStructureValue(responseMessageValue);
@@ -388,8 +382,7 @@ namespace Serilog.Sinks.Raygun
                 {
                     userIdentifier = new RaygunIdentifierMessage(identifierSplit[1]);
 
-                    string[] isAnonymousSplit =
-                        properties[1].Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] isAnonymousSplit = properties[1].Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                     if (isAnonymousSplit.Length == 2)
                     {
                         userIdentifier.IsAnonymous = "True".Equals(isAnonymousSplit[1]);
@@ -424,8 +417,7 @@ namespace Serilog.Sinks.Raygun
             return userIdentifier;
         }
 
-        private static RaygunResponseMessage BuildResponseMessageFromStructureValue(
-            StructureValue responseMessageStructure)
+        private static RaygunResponseMessage BuildResponseMessageFromStructureValue(StructureValue responseMessageStructure)
         {
             var responseMessage = new RaygunResponseMessage();
 
@@ -448,8 +440,7 @@ namespace Serilog.Sinks.Raygun
             return responseMessage;
         }
 
-        private static RaygunRequestMessage BuildRequestMessageFromStructureValue(
-            StructureValue requestMessageStructure)
+        private static RaygunRequestMessage BuildRequestMessageFromStructureValue(StructureValue requestMessageStructure)
         {
             var requestMessage = new RaygunRequestMessage();
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -21,7 +21,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Mindscape.Raygun4Net;
 
-#if NET
+#if NET || NETSTANDARD
 using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
 
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.Raygun
         private readonly IEnumerable<Type> _wrapperExceptions;
         private readonly IEnumerable<string> _ignoredFormFieldNames;
 
-#if NET
+#if NET || NETSTANDARD
         private readonly IHttpContextAccessor _httpAccessor;
         private readonly RaygunSettings _settings;
         private readonly IRaygunAspNetCoreClientProvider _raygunAspNetCoreClientProvider;
@@ -105,7 +105,7 @@ namespace Serilog.Sinks.Raygun
             string tagsProperty = "Tags",
             string userInfoProperty = null,
             Action<OnBeforeSendArguments> onBeforeSend = null
-#if NET
+#if NET || NETSTANDARD
             , RaygunSettings settings = null
             , IRaygunAspNetCoreClientProvider raygunAspNetCoreClientProvider = null
 #endif
@@ -123,7 +123,7 @@ namespace Serilog.Sinks.Raygun
             _wrapperExceptions = wrapperExceptions;
             _ignoredFormFieldNames = ignoredFormFieldNames;
             
-#if NET
+#if NET || NETSTANDARD
             _settings = settings ?? new RaygunSettings
             {
                 ApiKey = _applicationKey
@@ -137,20 +137,11 @@ namespace Serilog.Sinks.Raygun
         private RaygunClient GetClient()
         {
             RaygunClient client = null;
-#if NET 
+#if NET || NETSTANDARD 
             client = _raygunAspNetCoreClientProvider.GetClient(_raygunAspNetCoreClientProvider.GetRaygunSettings(_settings), _httpAccessor.HttpContext);
 #else
-            client = new RaygunClient(_applicationKey);
+            client = string.IsNullOrWhiteSpace(_applicationKey) ? new RaygunClient() : new RaygunClient(_applicationKey);
 #endif
-
-
-            //_client = raygunAspNetCoreClientProvider.GetClient(raygunAspNetCoreClientProvider.GetRaygunSettings());
-
-//#if NETSTANDARD2_0
-            //_client = new RaygunClient(applicationKey);
-// #else
-//             _client = string.IsNullOrWhiteSpace(applicationKey) ? new RaygunClient() : new RaygunClient(applicationKey);
-// #endif
 
             // Raygun4Net adds these two wrapper exceptions by default, but as there is no way to remove them through this Serilog sink, we replace them entirely with the configured wrapper exceptions.
             client.RemoveWrapperExceptions(typeof(TargetInvocationException),
@@ -297,7 +288,7 @@ namespace Serilog.Sinks.Raygun
                         properties.Remove(_groupKeyProperty);
                     }
 
-#if NET
+#if NET || NETSTANDARD
                     // Add Http request/response messages if present and not already set
                     if (details.Request == null &&
                         properties.TryGetValue(RaygunClientHttpEnricher.RaygunRequestMessagePropertyName,

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -17,15 +17,19 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using Serilog.Core;
+using Serilog.Events;
 using Mindscape.Raygun4Net;
-#if NETSTANDARD2_0
+
+#if NET
+using Microsoft.AspNetCore.Http;
 using Mindscape.Raygun4Net.AspNetCore;
+
 #else
+using Mindscape.Raygun4Net;
 using Mindscape.Raygun4Net.Builders;
 using Mindscape.Raygun4Net.Messages;
 #endif
-using Serilog.Core;
-using Serilog.Events;
 
 namespace Serilog.Sinks.Raygun
 {
@@ -45,9 +49,19 @@ namespace Serilog.Sinks.Raygun
         private readonly string _groupKeyProperty;
         private readonly string _tagsProperty;
         private readonly string _userInfoProperty;
-        private readonly RaygunClient _client;
+        //private readonly RaygunClient _client;
         private readonly Action<OnBeforeSendArguments> _onBeforeSend;
+        private readonly string _applicationKey;
+        private readonly IEnumerable<Type> _wrapperExceptions;
+        private readonly IEnumerable<string> _ignoredFormFieldNames;
 
+#if NET
+        private readonly IHttpContextAccessor _httpAccessor;
+        private readonly RaygunSettings _settings;
+        private readonly IRaygunAspNetCoreClientProvider _raygunAspNetCoreClientProvider;
+#endif
+
+#if !NET
         /// <summary>
         /// Construct a sink that saves errors to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
         /// </summary>
@@ -62,6 +76,24 @@ namespace Serilog.Sinks.Raygun
         /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
         /// <param name="userInfoProperty">The property where a RaygunIdentifierMessage with more user information can optionally be provided.</param>
         /// <param name="onBeforeSend">The action to be executed right before a logging message is sent to Raygun</param>
+#else
+        /// <summary>
+        /// Construct a sink that saves errors to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
+        /// </summary>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="applicationKey">The application key as found on an application in your Raygun account.</param>
+        /// <param name="wrapperExceptions">If you have common outer exceptions that wrap a valuable inner exception which you'd prefer to group by, you can specify these by providing a list.</param>
+        /// <param name="userNameProperty">Specifies the property name to read the username from. By default it is UserName. Set to null if you do not want to use this feature.</param>
+        /// <param name="applicationVersionProperty">Specifies the property to use to retrieve the application version from. You can use an enricher to add the application version to all the log events. When you specify null, Raygun will use the assembly version.</param>
+        /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
+        /// <param name="ignoredFormFieldNames">Specifies the form field names which to ignore when including request form data.</param>
+        /// <param name="groupKeyProperty">The property containing the custom group key for the Raygun message.</param>
+        /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
+        /// <param name="userInfoProperty">The property where a RaygunIdentifierMessage with more user information can optionally be provided.</param>
+        /// <param name="onBeforeSend">The action to be executed right before a logging message is sent to Raygun</param>
+        /// <param name="settings">Allows you to provide settings for the Raygun service. If null, defaults are used.</param>
+        /// <param name="raygunAspNetCoreClientProvider">Provides a way to customize the Raygun client for ASP.NET Core applications. If null, a default client is used.</param>        
+#endif
         public RaygunSink(IFormatProvider formatProvider,
             string applicationKey,
             IEnumerable<Type> wrapperExceptions = null,
@@ -72,34 +104,71 @@ namespace Serilog.Sinks.Raygun
             string groupKeyProperty = "GroupKey",
             string tagsProperty = "Tags",
             string userInfoProperty = null,
-            Action<OnBeforeSendArguments> onBeforeSend = null)
+            Action<OnBeforeSendArguments> onBeforeSend = null
+#if NET
+            , RaygunSettings settings = null
+            , IRaygunAspNetCoreClientProvider raygunAspNetCoreClientProvider = null
+#endif
+        )
         {
             _formatProvider = formatProvider;
             _userNameProperty = userNameProperty;
             _applicationVersionProperty = applicationVersionProperty;
-            _tags = tags ?? new string[0];
+            _tags = tags ?? Array.Empty<string>();
             _groupKeyProperty = groupKeyProperty;
             _tagsProperty = tagsProperty;
             _userInfoProperty = userInfoProperty;
             _onBeforeSend = onBeforeSend;
+            _applicationKey = applicationKey;
+            _wrapperExceptions = wrapperExceptions;
+            _ignoredFormFieldNames = ignoredFormFieldNames;
             
+#if NET
+            _settings = settings ?? new RaygunSettings
+            {
+                ApiKey = _applicationKey
+            };
+            _raygunAspNetCoreClientProvider =
+                raygunAspNetCoreClientProvider ?? new DefaultRaygunAspNetCoreClientProvider();
+            _httpAccessor = new HttpContextAccessor();
+#endif
+        }
 
-#if NETSTANDARD2_0
-            _client = new RaygunClient(applicationKey);
+        private RaygunClient GetClient()
+        {
+            RaygunClient client = null;
+#if NET 
+            client = _raygunAspNetCoreClientProvider.GetClient(_raygunAspNetCoreClientProvider.GetRaygunSettings(_settings), _httpAccessor.HttpContext);
 #else
-            _client = string.IsNullOrWhiteSpace(applicationKey) ? new RaygunClient() : new RaygunClient(applicationKey);
+            client = new RaygunClient(_applicationKey);
 #endif
 
+
+            //_client = raygunAspNetCoreClientProvider.GetClient(raygunAspNetCoreClientProvider.GetRaygunSettings());
+
+//#if NETSTANDARD2_0
+            //_client = new RaygunClient(applicationKey);
+// #else
+//             _client = string.IsNullOrWhiteSpace(applicationKey) ? new RaygunClient() : new RaygunClient(applicationKey);
+// #endif
+
             // Raygun4Net adds these two wrapper exceptions by default, but as there is no way to remove them through this Serilog sink, we replace them entirely with the configured wrapper exceptions.
-            _client.RemoveWrapperExceptions(typeof(TargetInvocationException), Type.GetType("System.Web.HttpUnhandledException, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
+            client.RemoveWrapperExceptions(typeof(TargetInvocationException),
+                Type.GetType("System.Web.HttpUnhandledException, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
 
-            if (wrapperExceptions != null)
-                _client.AddWrapperExceptions(wrapperExceptions.ToArray());
+            if (_wrapperExceptions != null)
+            {
+                client.AddWrapperExceptions(_wrapperExceptions.ToArray());
+            }
 
-            if (ignoredFormFieldNames != null)
-                _client.IgnoreFormFieldNames(ignoredFormFieldNames.ToArray());
+            if (_ignoredFormFieldNames != null)
+            {
+                client.IgnoreFormFieldNames(_ignoredFormFieldNames.ToArray());
+            }
 
-            _client.CustomGroupingKey += OnCustomGroupingKey;
+            client.CustomGroupingKey += OnCustomGroupingKey;
+            
+            return client;
         }
 
         /// <summary>
@@ -129,14 +198,16 @@ namespace Serilog.Sinks.Raygun
             // Decide what exception object to send
             var exception = logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace());
 
+            var client = GetClient();
+            
             // Submit
             if (logEvent.Level == LogEventLevel.Fatal)
             {
-                _client.Send(exception, tags, properties);
+                client.Send(exception, tags, properties);
             }
             else
             {
-                _client.SendInBackground(exception, tags, properties);
+                client.SendInBackground(exception, tags, properties);
             }
         }
 
@@ -162,7 +233,8 @@ namespace Serilog.Sinks.Raygun
                         {
                             ClassName = properties[LogMessageTemplateProperty].AsString(),
                             Message = properties[RenderedLogMessageProperty].AsString(),
-                            StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
+                            StackTrace =
+                                RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
                         };
                     }
 
@@ -225,10 +297,11 @@ namespace Serilog.Sinks.Raygun
                         properties.Remove(_groupKeyProperty);
                     }
 
-#if NETSTANDARD2_0
+#if NET
                     // Add Http request/response messages if present and not already set
                     if (details.Request == null &&
-                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunRequestMessagePropertyName, out var requestMessageProperty) &&
+                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunRequestMessagePropertyName,
+                            out var requestMessageProperty) &&
                         requestMessageProperty is StructureValue requestMessageValue)
                     {
                         details.Request = BuildRequestMessageFromStructureValue(requestMessageValue);
@@ -236,7 +309,8 @@ namespace Serilog.Sinks.Raygun
                     }
 
                     if (details.Response == null &&
-                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunResponseMessagePropertyName, out var responseMessageProperty) &&
+                        properties.TryGetValue(RaygunClientHttpEnricher.RaygunResponseMessagePropertyName,
+                            out var responseMessageProperty) &&
                         responseMessageProperty is StructureValue responseMessageValue)
                     {
                         details.Response = BuildResponseMessageFromStructureValue(responseMessageValue);
@@ -250,7 +324,7 @@ namespace Serilog.Sinks.Raygun
                         .ToDictionary(a => a.Name, b => b.Value);
                 }
             }
-            
+
             // Call onBeforeSend
             if (_onBeforeSend != null)
             {
@@ -323,7 +397,8 @@ namespace Serilog.Sinks.Raygun
                 {
                     userIdentifier = new RaygunIdentifierMessage(identifierSplit[1]);
 
-                    string[] isAnonymousSplit = properties[1].Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] isAnonymousSplit =
+                        properties[1].Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                     if (isAnonymousSplit.Length == 2)
                     {
                         userIdentifier.IsAnonymous = "True".Equals(isAnonymousSplit[1]);
@@ -358,7 +433,8 @@ namespace Serilog.Sinks.Raygun
             return userIdentifier;
         }
 
-        private static RaygunResponseMessage BuildResponseMessageFromStructureValue(StructureValue responseMessageStructure)
+        private static RaygunResponseMessage BuildResponseMessageFromStructureValue(
+            StructureValue responseMessageStructure)
         {
             var responseMessage = new RaygunResponseMessage();
 
@@ -381,7 +457,8 @@ namespace Serilog.Sinks.Raygun
             return responseMessage;
         }
 
-        private static RaygunRequestMessage BuildRequestMessageFromStructureValue(StructureValue requestMessageStructure)
+        private static RaygunRequestMessage BuildRequestMessageFromStructureValue(
+            StructureValue requestMessageStructure)
         {
             var requestMessage = new RaygunRequestMessage();
 

--- a/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
+++ b/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
@@ -4,14 +4,26 @@
 
 		<IsPackable>false</IsPackable>
 
-		<TargetFrameworks>netstandard2.0;net46;net461</TargetFrameworks>
+		<TargetFrameworks>net6.0;net462</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-		<PackageReference Include="NUnit" Version="3.13.1" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageReference Include="coverlet.collector" Version="3.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net5.0'">
+		<PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+		<PackageReference Include="Mindscape.Raygun4Net" Version="7.0.1"/>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mindscape.Raygun4Net;
-#if NETSTANDARD2_0
+#if NET
 using Mindscape.Raygun4Net.AspNetCore;
 #else
 using Mindscape.Raygun4Net.Builders;

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/OnBeforeSendActionTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mindscape.Raygun4Net;
-#if NET
+#if NET || NETSTANDARD
 using Mindscape.Raygun4Net.AspNetCore;
 #else
 using Mindscape.Raygun4Net.Builders;


### PR DESCRIPTION
When using Raygun with Serilog, it's not possible to use a custom client, i.e

```
public class CustomRaygunProvider : DefaultRaygunAspNetCoreClientProvider
{
    private static readonly string ServiceName = Process.GetCurrentProcess().ProcessName;
    private static readonly string ServiceVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion ?? string.Empty;

    public override RaygunClient GetClient(RaygunSettings settings, HttpContext context)
    {
        var client = base.GetClient(settings, context);

        var email = context.User.FindFirstValue("email");

        client.UserInfo = new RaygunIdentifierMessage(email)
        {
            IsAnonymous = false,
            Identifier = context.User.FindFirstValue("sub"),
            Email = email,
            FullName = context.User.FindFirstValue("preferred_username")
        };

        client.ApplicationVersion = ServiceVersion;

        client.SendingMessage += (_, args) =>
        {
            args.Message.Details.Tags ??= new List<string>();
            args.Message.Details.Tags.Add(ServiceVersion);
            args.Message.Details.Tags.Add(ServiceName);
        };

        return client;
    }
}
```

This would be registered with asp .net core:

```
builder.Services.AddRaygun(builder.Configuration, new RaygunMiddlewareSettings
{
    ClientProvider = new CustomRaygunProvider()
});
```

This PR allows the configuration of the custom provider like so:

```
var key = context.Configuration["RaygunSettings:ApiKey"];
builder.Host.UseSerilog((context, configuration) =>
{
    configuration
        .WriteTo.Console()
        .WriteTo.Raygun(applicationKey: key, settings: new RaygunSettings
        {
            ApiKey = key
        },
        raygunAspNetCoreClientProvider: new CustomRaygunProvider());
});
```

This allows consistency between asp .net and serilog. 