### PR TITLE
Bump raygun4net dependency to 7.1.0

### DIFF
--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -24,11 +24,11 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>
+        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.1.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <PackageReference Include="Mindscape.Raygun4Net" Version="7.0.1"/>
+        <PackageReference Include="Mindscape.Raygun4Net" Version="7.1.0"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
     </ItemGroup>
 

--- a/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
+++ b/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
@@ -18,11 +18,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net5.0'">
-		<PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0"/>
+		<PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="7.1.0"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-		<PackageReference Include="Mindscape.Raygun4Net" Version="7.0.1"/>
+		<PackageReference Include="Mindscape.Raygun4Net" Version="7.1.0"/>
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
 	</ItemGroup>
 


### PR DESCRIPTION
Bumps the raygun4net dependency to 7.1.0 so the environment information is collected correctly.