### PR TITLE
Drop Serilog dependency version to 2.12.0 and include Enricher readme

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,10 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
+### v7.4.0
+- Drop Serilog dependency from 3.0.0 to 2.12.0
+- Include new [Enricher Readme](README-ENRICHER.md) in repo for those who still wish to use the ASP.NET Core Enricher
+  - An example of this usage can be found in Serilog.Sinks.Raygun.SampleWebApp project
+
 ### v7.3.0
 - Drop ASP.NET Core Enricher (use `Serilog.AspNetCore` package instead)
 - Removes dependency on `Mindscape.Raygun4Net.AspNetCore` package

--- a/README-ENRICHER.md
+++ b/README-ENRICHER.md
@@ -1,63 +1,16 @@
-using Mindscape.Raygun4Net.AspNetCore;
-using Mindscape.Raygun4Net.AspNetCore.Builders;
-using Serilog;
-using Serilog.Core;
-using Serilog.Events;
-using RaygunSettings = Mindscape.Raygun4Net.AspNetCore.RaygunSettings;
+## ASP.NET Core Enricher
 
-var apiKey = Environment.GetEnvironmentVariable("RAYGUN_APIKEY") ?? "";
+With the release of v7.3.0, the ASP.NET Core Enricher has been removed from this package. 
+This is because the enricher had a dependency on `Mindscape.Raygun4Net.AspNetCore`, which in turn had a dependency
+on `Microsoft.AspNetCore.App`. Attempting to use `Serilog.Sinks.Raygun` in a MAUI app would result in an error.
 
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
-    .Enrich.With(new RaygunClientHttpEnricher())
-    .WriteTo.Console()
-    .WriteTo.Raygun(apiKey)
-    .CreateLogger();
+If you still wish to use the enricher you can follow the steps outlined below.
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
+### Create a new Enricher class
 
-    // Add services to the container.
-    builder.Services.AddControllersWithViews();
-    builder.Services.AddHttpContextAccessor();
+Note: You will need to include a dependency on [Mindscape.Raygun4Net.AspNetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.AspNetCore) for this to work.
 
-    builder.Host.UseSerilog();
-
-    var app = builder.Build();
-
-
-    // Configure the HTTP request pipeline.
-    if (!app.Environment.IsDevelopment())
-    {
-        app.UseExceptionHandler("/Home/Error");
-        // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-        app.UseHsts();
-    }
-
-    app.UseHttpsRedirection();
-    app.UseStaticFiles();
-
-    app.UseRouting();
-
-    app.UseAuthorization();
-
-    app.MapControllerRoute(
-        name: "default",
-        pattern: "{controller=Home}/{action=Index}/{id?}");
-
-    app.Run();
-}
-catch (Exception e)
-{
-    Log.Error(e, "Logging error");
-}
-finally
-{
-    Log.CloseAndFlush();
-}
-
-
+```c#
 public class RaygunClientHttpEnricher : ILogEventEnricher
 {
     private const string RaygunRequestMessagePropertyName = "RaygunSink_RequestMessage";
@@ -115,3 +68,26 @@ public class RaygunClientHttpEnricher : ILogEventEnricher
         logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(RaygunResponseMessagePropertyName, httpResponseMessage, true));
     }
 }
+```
+
+### Include the enricher into Serilog configuration
+
+Please note, this an example configuration to show the use of `Enrich.With(...)`
+```c#
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .Enrich.With(new RaygunClientHttpEnricher())
+    .WriteTo.Console()
+    .WriteTo.Raygun("*your api key*")
+    .CreateLogger();
+```
+
+### Ensure HttpContextAccessor is registered with the DI container
+
+When setting up the DI container, ensure that the `HttpContextAccessor` is registered.
+
+```c#
+services.AddHttpContextAccessor();
+```
+
+When errors are thrown they should now contain the original information from the Raygun Enricher.

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Log.Logger = new LoggerConfiguration()
 
 Properties included from other Serilog Enrichers should automatically be included into the Raygun errors.
 
-To use the old Raygun Enricher you can follow the [Enricher Readme](README-ENRICHER.md) to add the enricher to your project.
+To use the old Raygun Enricher you can follow the [Enricher Readme](https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/README-ENRICHER.md) to add the enricher to your project.
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration fil
         "Name": "Raygun",
         "Args": {
           "applicationKey": "paste_your_api_key_here"
-		}
+        }
       }
     ]
   }  
@@ -277,57 +277,9 @@ Log.Logger = new LoggerConfiguration()
 
 ## Enrich with HTTP request and response data
 
-This is only valid for .NET Standard 2.0 and above projects. 
+Properties included from other Serilog Enrichers should automatically be included into the Raygun errors.
 
-In full framework, ASP.NET applications, the HTTP request and response are available to Raygun4Net through the `HttpContext.Current` accessor. 
-
-For .NET Core, this won't be avaliable. Therefore, you'll need to add the Serilog enricher using the `WithHttpDataForRaygun` method to capture the HTTP request and response data.
-
-
-### Configuration
-
-All parameters to WithHttpDataForRaygun are optional.
-
-```cs
-Log.Logger = new LoggerConfiguration()
-  .WriteTo.Raygun("paste_your_api_key_here")
-  .Enrich.WithHttpDataForRaygun(
-    new HttpContextAccessor(),
-    LogEventLevel.Error,
-    RaygunSettings)
-  .CreateLogger();
-```
-
-When configuring using a JSON configuration file use the following example.
-
-```json
-{
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Raygun"
-    ],
-    "Enrich": [
-      {
-        "Name": "WithHttpDataForRaygun",
-        "Args": {
-          "RaygunSettings": {
-            "IsRawDataIgnored": true,
-            "UseXmlRawDataFilter": true,
-            "IsRawDataIgnoredWhenFilteringFailed": true,
-            "UseKeyValuePairRawDataFilter": true,
-            "IgnoreCookieNames": ["CookieName"],
-            "IgnoreHeaderNames": ["HeaderName"],
-            "IgnoreFormFieldNames": ["FormFieldName"],
-            "IgnoreQueryParameterNames": ["QueryParameterName"],
-            "IgnoreSensitiveFieldNames": ["SensitiveFieldNames"],
-            "IgnoreServerVariableNames": ["ServerVariableName"]
-          }
-        }
-      }
-    ]
-  }
-}
-```
+To use the old Raygun Enricher you can follow the [Enricher Readme](README-ENRICHER.md) to add the enricher to your project.
 
 ------
 

--- a/Raygun.Serilog.sln
+++ b/Raygun.Serilog.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		CHANGE-LOG.md = CHANGE-LOG.md
 		LICENSE = LICENSE
 		README.md = README.md
+		README-ENRICHER.md = README-ENRICHER.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.SampleWebApp", "sampleApps\Serilog.Sinks.Raygun.SampleWebApp\Serilog.Sinks.Raygun.SampleWebApp.csproj", "{73E023EF-23CD-4450-AD12-6C37DC8ACB18}"

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Serilog.Sinks.Raygun.SampleConsoleApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Serilog.Sinks.Raygun.SampleConsoleApp.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Serilog" Version="3.0.0" />
+      <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="8.2.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     </ItemGroup>

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -10,7 +10,7 @@
         <Company>Serilog</Company>
         <Product>Serilog.Sinks.Raygun</Product>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
+        <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
         <PackageIcon>serilog-sink-nuget.png</PackageIcon>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
@@ -36,7 +36,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="3.0.0"/>
+        <PackageReference Include="Serilog" Version="2.12.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -18,8 +18,9 @@
         <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
-        <VersionPrefix>7.3.0</VersionPrefix>
-        <PackageVersion>7.3.0-pre-2</PackageVersion>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <VersionPrefix>7.4.0</VersionPrefix>
+        <PackageVersion>7.4.0-pre-1</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 
@@ -40,6 +41,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
         <None Include="..\..\serilog-sink-nuget.png" Pack="true" PackagePath="\"/>
     </ItemGroup>
     


### PR DESCRIPTION
- Drop Serilog dependency from 3.0.0 to 2.12.0
- Include new [Enricher Readme](README-ENRICHER.md) in repo for those who still wish to use the ASP.NET Core Enricher
  - An example of this usage can be found in Serilog.Sinks.Raygun.SampleWebApp project