### PR TITLE
Fix RaygunSink not formatting request/response data for code Enricher

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,9 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
+### v7.5.0
+- Fixed issue in RaygunSink where it was not setting Request/Response messages if supplied by the code Enricher
+- Bumped Raygun.NetCore dependency to 8.2.0 to fix issue where custom RaygunClient with HttpClient could not be used
+
 ### v7.4.0
 - Drop Serilog dependency from 3.0.0 to 2.12.0
 - Include new [Enricher Readme](README-ENRICHER.md) in repo for those who still wish to use the ASP.NET Core Enricher

--- a/README-ENRICHER.md
+++ b/README-ENRICHER.md
@@ -13,18 +13,35 @@ Note: You will need to include a dependency on [Mindscape.Raygun4Net.AspNetCore]
 ```c#
 public class RaygunClientHttpEnricher : ILogEventEnricher
 {
+    // These names are used by the RaygunSink to extract the request/response messages from the logEvent properties.
     private const string RaygunRequestMessagePropertyName = "RaygunSink_RequestMessage";
     private const string RaygunResponseMessagePropertyName = "RaygunSink_ResponseMessage";
 
-    readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly LogEventLevel _restrictedToMinimumLevel;
-    private readonly RaygunSettings _raygunSettings;
+    private readonly RaygunRequestMessageOptions _messageOptions; 
 
     public RaygunClientHttpEnricher(IHttpContextAccessor? httpContextAccessor = null, LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error, RaygunSettings? raygunSettings = null)
     {
         _httpContextAccessor = httpContextAccessor ?? new HttpContextAccessor();
         _restrictedToMinimumLevel = restrictedToMinimumLevel;
-        _raygunSettings = raygunSettings ?? new RaygunSettings();
+        
+        var settings = raygunSettings ?? new RaygunSettings();
+        
+        _messageOptions = new RaygunRequestMessageOptions
+        {
+            IsRawDataIgnored = settings.IsRawDataIgnored,
+            UseXmlRawDataFilter = settings.UseXmlRawDataFilter,
+            IsRawDataIgnoredWhenFilteringFailed = settings.IsRawDataIgnoredWhenFilteringFailed,
+            UseKeyValuePairRawDataFilter = settings.UseKeyValuePairRawDataFilter
+        };
+
+        _messageOptions.AddCookieNames(settings.IgnoreCookieNames ?? Array.Empty<string>());
+        _messageOptions.AddHeaderNames(settings.IgnoreHeaderNames ?? Array.Empty<string>());
+        _messageOptions.AddFormFieldNames(settings.IgnoreFormFieldNames ?? Array.Empty<string>());
+        _messageOptions.AddQueryParameterNames(settings.IgnoreQueryParameterNames ?? Array.Empty<string>());
+        _messageOptions.AddSensitiveFieldNames(settings.IgnoreSensitiveFieldNames ?? Array.Empty<string>());
+        _messageOptions.AddServerVariableNames(settings.IgnoreServerVariableNames ?? Array.Empty<string>());
     }
 
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
@@ -39,23 +56,8 @@ public class RaygunClientHttpEnricher : ILogEventEnricher
             return;
         }
 
-        var options = new RaygunRequestMessageOptions
-        {
-            IsRawDataIgnored = _raygunSettings.IsRawDataIgnored,
-            UseXmlRawDataFilter = _raygunSettings.UseXmlRawDataFilter,
-            IsRawDataIgnoredWhenFilteringFailed = _raygunSettings.IsRawDataIgnoredWhenFilteringFailed,
-            UseKeyValuePairRawDataFilter = _raygunSettings.UseKeyValuePairRawDataFilter
-        };
-
-        options.AddCookieNames(_raygunSettings.IgnoreCookieNames ?? Array.Empty<string>());
-        options.AddHeaderNames(_raygunSettings.IgnoreHeaderNames ?? Array.Empty<string>());
-        options.AddFormFieldNames(_raygunSettings.IgnoreFormFieldNames ?? Array.Empty<string>());
-        options.AddQueryParameterNames(_raygunSettings.IgnoreQueryParameterNames ?? Array.Empty<string>());
-        options.AddSensitiveFieldNames(_raygunSettings.IgnoreSensitiveFieldNames ?? Array.Empty<string>());
-        options.AddServerVariableNames(_raygunSettings.IgnoreServerVariableNames ?? Array.Empty<string>());
-
         var httpRequestMessage = RaygunAspNetCoreRequestMessageBuilder
-            .Build(_httpContextAccessor.HttpContext, options)
+            .Build(_httpContextAccessor.HttpContext, _messageOptions)
             .GetAwaiter()
             .GetResult();
 
@@ -64,8 +66,8 @@ public class RaygunClientHttpEnricher : ILogEventEnricher
         // The Raygun request/response messages are stored in the logEvent properties collection.
         // When the error is sent to Raygun, these messages are extracted from the known properties
         // and then removed so as to not duplicate data in the payload.
-        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(RaygunRequestMessagePropertyName, httpRequestMessage, true));
-        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(RaygunResponseMessagePropertyName, httpResponseMessage, true));
+        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(RaygunRequestMessagePropertyName, httpRequestMessage, true));
+        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(RaygunResponseMessagePropertyName, httpResponseMessage, true));
     }
 }
 ```

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -28,7 +28,7 @@
                           '$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="8.0.0"/>
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="8.2.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -19,8 +19,8 @@
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>7.4.0</VersionPrefix>
-        <PackageVersion>7.4.0-pre-1</PackageVersion>
+        <VersionPrefix>7.5.0</VersionPrefix>
+        <PackageVersion>7.5.0-pre-1</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 


### PR DESCRIPTION
When removing the enricher, I removed the code which formatted the request/response data. This PR re-introduces the methods to do the formatting so when the code enricher is used it will format like it used to.

Also bumped the dependency on Raygun4Net so that when Custom Raygun Client Provider is used it will automatically allow you to pass in the HttpClient, without this bump the implicit dependency would be v8.0.0 instead of v8.2.0 which does not have the ctor change. 