### PR TITLE
Implementation of RaygunSinkV2 for better registration with existing Raygun4Net providers

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,13 +1,14 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
-### v7.6.0
+
+### v8.0.0
 - Updated Raygun4Net dependency
 - Added `ApplicationBuilderExtensions` to allow `AddRaygun(...)` for use in Console/Services
 - Implemented new `RaygunSinkV2` which is cut down but supports using whatever RaygunClient is registered via DI
   - This treats RaygunClient as a singleton and uses it to send messages
   - Adds support for using Raygun4Net.AspNetCore package to register RaygunClient in DI
   - Adds support for `IRaygunUserProvider` to be registered in DI
-  - See: 
+  - See: https://github.com/MindscapeHQ/serilog-sinks-raygun/pull/71
 - Notes: RaygunSink is left unchanged, this should not be a breaking change for anyone using the package as it is, 
          but the new `RaygunSinkV2` is available for those who wish to use it. The new sink is more flexible and allows 
          for custom RaygunClient instances to be used.

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,16 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
+### v7.6.0
+- Updated Raygun4Net dependency
+- Implemented new `RaygunSinkV2` which is cut down but supports using whatever RaygunClient is registered via DI
+  - This treats RaygunClient as a singleton and uses it to send messages
+  - Adds support for using Raygun4Net.AspNetCore package to register RaygunClient in DI
+  - Adds support for `IRaygunUserProvider` to be registered in DI
+  - See: 
+- Notes: RaygunSink is left unchanged, this should not be a breaking change for anyone using the package as it is, 
+         but the new `RaygunSinkV2` is available for those who wish to use it. The new sink is more flexible and allows 
+         for custom RaygunClient instances to be used.
+
 ### v7.5.0
 - Fixed issue in RaygunSink where it was not setting Request/Response messages if supplied by the code Enricher
 - Bumped Raygun.NetCore dependency to 8.2.0 to fix issue where custom RaygunClient with HttpClient could not be used

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -4,13 +4,13 @@
 ### v8.0.0
 - Updated Raygun4Net dependency
 - Added `ApplicationBuilderExtensions` to allow `AddRaygun(...)` for use in Console/Services
-- Implemented new `RaygunSinkV2` which is cut down but supports using whatever RaygunClient is registered via DI
+- Implemented new `RaygunClientSink` which is cut down but supports using whatever RaygunClient is registered via DI
   - This treats RaygunClient as a singleton and uses it to send messages
   - Adds support for using Raygun4Net.AspNetCore package to register RaygunClient in DI
   - Adds support for `IRaygunUserProvider` to be registered in DI
   - See: https://github.com/MindscapeHQ/serilog-sinks-raygun/pull/71
 - Notes: RaygunSink is left unchanged, this should not be a breaking change for anyone using the package as it is, 
-         but the new `RaygunSinkV2` is available for those who wish to use it. The new sink is more flexible and allows 
+         but the new `RaygunClientSink` is available for those who wish to use it. The new sink is more flexible and allows 
          for custom RaygunClient instances to be used.
 
 ### v7.5.0

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -2,6 +2,7 @@
 
 ### v7.6.0
 - Updated Raygun4Net dependency
+- Added `ApplicationBuilderExtensions` to allow `AddRaygun(...)` for use in Console/Services
 - Implemented new `RaygunSinkV2` which is cut down but supports using whatever RaygunClient is registered via DI
   - This treats RaygunClient as a singleton and uses it to send messages
   - Adds support for using Raygun4Net.AspNetCore package to register RaygunClient in DI

--- a/README-NET-FRAMEWORK.md
+++ b/README-NET-FRAMEWORK.md
@@ -1,0 +1,348 @@
+# serilog-sinks-raygun
+
+Serilog Sinks error and performance monitoring with Raygun is available using the serilog-sinks-raygun provider.
+
+serilog-sinks-raygun is a library that you can easily add to your website or web application, which will then monitor your application and display all Serilog errors and issues affecting your users within your Raygun account. Installation is painless.
+
+The provider is a single package (Serilog.Sinks.Raygun) which includes the sole dependency (Serilog), allowing you to drop it straight in.
+
+## Getting started
+
+## Step 1 - Add packages
+
+Install the Serilog (if not included already) and Serilog.Sinks.Raygun package into your project. You can either use the below dotnet CLI command, or the NuGet management GUI in the IDE you use.
+
+```bash
+ dotnet add package Serilog
+ dotnet add package Serilog.Sinks.Raygun 
+```
+
+------
+
+## Step 2 - Initialization
+There are two recommended options for initializing the Raygun Serilog Sink. Which option is best to use depends on the application. 
+
+### Option 1 - Using logger configuration
+
+You can initialize Raygun's Serilog Sink through a Logger Configuration. This should be done inside the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
+
+**Minimum setup example:**
+
+```cs
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun("paste_your_api_key_here")
+    .CreateLogger();
+```
+
+**Example setup with optional properties:**
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun("paste_your_api_key_here",
+      ListOfWrapperExceptions,
+      "CustomUserNameProperty",
+      "CustomAppVersionProperty",
+      LogEventLevel.Information,
+      CustomFormatProvider,
+      new[] { "globalTag1", "globalTag2" },
+      new[] { "ignoreField1", "ignoreField2" },
+      "CustomGroupKeyProperty",
+      "CustomTagsProperty",
+      "CustomUserInfoProperty",
+      onBeforeSendArguments => { /*OnBeforeSend: Action<onBeforeSendArguments>*/ })
+    .CreateLogger();
+```
+------
+
+### Option 2 - Using the JSON configuration file
+You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration file using the following examples.
+
+**Minimum setup example:**
+
+```json
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Raygun"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Raygun",
+        "Args": {
+          "applicationKey": "paste_your_api_key_here"
+        }
+      }
+    ]
+  }  
+}
+```
+
+**Example setup with optional properties:**
+```json
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Raygun"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Raygun",
+        "Args": {
+          "applicationKey": "paste_your_api_key_here",
+          "userNameProperty": "CustomUserNameProperty",
+          "applicationVersionProperty": "CustomAppVersionProperty",
+          "restrictedToMinimumLevel": "Error",
+          "ignoredFormFieldNames": ["ignoreField1", "ignoreField2"],
+          "tags": ["globalTag1", "globalTag2"],
+          "groupKeyProperty": "CustomGroupKeyProperty",
+          "tagsProperty": "CustomTagsProperty",
+          "userInfoProperty": "CustomUserInfoProperty"
+        }
+      }
+    ]
+  }  
+}
+```
+
+----
+
+## Configuration Properties
+
+**applicationKey**
+
+`type: string`
+
+`required`
+
+Each application you create in Raygun will have an API key which you can pass in here to specify where the crash reports will be sent to. Although this is required, you can set this to null or empty string which would result in crash reports not being sent. This can be useful if you want to configure your local environment to not send crash reports to Raygun and then use config transforms or the like to provide an API key for other environments.
+
+**wrapperExceptions**
+
+`type: IEnumerable<Type>`
+
+`default: null`
+
+This is a list of wrapper exception types that you're not interested in logging to Raygun. Whenever an undesired wrapper exception is logged, it will be discarded and only the inner exception(s) will be logged.
+
+For example, you may not be interested in the details of an AggregateException, so you could include `typeof(AggregateException)` in this list of wrapperExceptions. All inner exceptions of any logged AggregateException would then be sent to Raygun as separate crash reports.
+
+
+**userNameProperty**
+
+`type: string`
+
+`default: UserName`
+
+This is so you can specify the username to log the information as a part of the crash report. By default it is UserName. You can set this to be to `null` if you do not want to use this feature.
+
+```cs
+Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random error"), "other information");
+```
+
+
+**applicationVersionProperty**
+
+`type: string`
+
+`default: ApplicationVersion`
+
+By default, crash reports sent to Raygun will have an ApplicationVersion field based on the version of the entry assembly for your application. If this is not being picked up correctly, or if you want to provide a different version, then you can do so by including the desired value in the logging properties collection.
+
+You can specify the property key that you place the version in by using this `applicationVersionProperty` setting. Otherwise the version will be read from the "ApplicationVersion" key.
+
+```cs
+Log.ForContext("CustomAppVersionProperty", "1.2.11").Error(new Exception("random error"), "other information");
+```
+
+**restrictedToMinimumLevel**
+
+`type: LogEventLevel`
+
+`default: LogEventLevel.Error`
+
+You can set the minimum log event level required in order to write an event to the sink. By default, this is set to Error as Raygun is mostly used for error reporting.
+
+**formatProvider**
+
+`type: IFormatProvider`
+
+`default: null`
+
+This property supplies culture-specific formatting information. By default, it is null.
+
+**tags**
+
+`type: IEnumerable<string>`
+
+`default: null`
+
+This is a list of global tags that will be included on every crash report sent with this Serilog sink.
+
+
+**ignoredFormFieldNames**
+
+`type: IEnumerable<string>`
+
+`default: null`
+
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). This option lets you specify a list of form fields that you do not want to be sent to Raygun.
+
+Setting `ignoredFormFieldNames` to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
+
+Note that HTTP headers, query parameters, cookies, server variables and raw request data can also be filtered out. Configuration to do so is described in the [RaygunSettings](#raygun4net-features-configured-via-raygunsettings) section further below.
+
+The `ignoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
+
+
+**groupKeyProperty**
+
+`type: string`
+
+`default: GroupKey`
+
+Crash reports sent to Raygun will be automatically grouped together based on stack trace and exception type information. The `groupKeyProperty` setting specifies a key in the logging properties collection where you can provide a grouping key. Crash reports containing a grouping key will not be grouped automatically by Raygun. Instead, crash reports with matching custom grouping keys will be grouped together.
+
+```cs
+Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Exception("random error"), "other information");
+```
+
+
+**tagsProperty**
+
+`type: string`
+
+`default: Tags`
+
+This allows you to specify a key in the properties collection that contains a list of tags to include on crash reports. Note that these will be included in addition to any global tags [described above](#tags). If you set a list of tags in the properties collection multiple times (e.g. at different logging scopes) then only the latest list of tags will be used.
+
+```cs
+Log.ForContext("CustomTagsProperty", new[] {"tag1", "tag2"}).Error(new Exception("random error"), "other information");
+Log.Error(new Exception("random error"), "other information {@CustomTagsProperty}", new[] {"tag3", "tag4"});
+```
+
+**userInfoProperty**
+
+`type: string`
+
+`default: null`
+
+This is null by default, so you need to configure the `userInfoProperty` name if you want to log more user information in this way. This will cause the provided RaygunIdentifierMessage to be included in the "User" section of the Raygun payload, allowing the information to be picked up by the "Users" section of the Raygun service. It's recommended to destructure the RaygunIdentifierMessage, but this feature will still work if you don't. Sending user information in this way will overwrite the use of the `userNameProperty`.
+
+The user identifier passed into the RaygunIdentifierMessage constructor could be the users name, email address, database id or whatever works best for you to identify unique users.
+
+```cs
+var userInfo = new RaygunIdentifierMessage("12345")
+{
+    FirstName = "John",
+    FullName = "John Doe",
+    Email = "johndoe@email.address"
+};
+
+Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("random error"), "other information");
+```
+
+
+**onBeforeSend**
+
+`type: Action<OnBeforeSendParameters>`
+
+`default: null`
+
+This action allows you to manipulate the crash report payloads that get sent to Raygun. By default it is `null`, so you don't need to set it in the constructor. If the action is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it gets called just before the crash report payload gets serialized and sent to Raygun. The arguments to the action are of type `Struct OnBeforeSendArguments`; they are passed to the action when it is called and contain references to the following objects passed by the Raygun client object:
+
+```cs
+// Abstracted away version of the struct to just show the properties
+struct OnBeforeSendArguments
+{
+    System.Exception Exception;
+    Mindscape.Raygun4Net.Messages.RaygunMessage RaygunMessage;
+}
+```
+
+The provided action can read and/or modify their properties accordingly to produce the desired effect. For example, one can change the `MachineName` property in the `Details` of the `RaygunMessage` as follows:
+
+ ```cs
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun(
+        applicationKey: "paste_your_api_key_here",
+        onBeforeSend: arguments => { 
+            arguments.RaygunMessage.Details.MachineName = "MyMachine";
+        })
+    .CreateLogger();
+```
+
+------
+
+## Enrich with HTTP request and response data
+
+Properties included from other Serilog Enrichers should automatically be included into the Raygun errors.
+
+To use the old Raygun Enricher you can follow the [Enricher Readme](https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/README-ENRICHER.md) to add the enricher to your project.
+
+------
+
+## Raygun4Net features configured via RaygunSettings
+
+This sink wraps the [Raygun4Net](https://github.com/MindscapeHQ/raygun4net) provider to build a crash report from an Exception and send it to Raygun. This makes the following Raygun4Net features available to you. To use these features, you need to add RaygunSettings to your configuration as explained below which is separate to the Serilog configuration.
+
+
+**.NET Framework**
+
+Add the following section within the configSections element of your app.config or web.config file.
+
+```xml
+<section name="RaygunSettings" type="Mindscape.Raygun4Net.RaygunSettings, Mindscape.Raygun4Net"/>
+```
+
+Then add a RaygunSettings element containing the desired settings somewhere within the configuration element of the app.config or web.config file.
+
+```xml
+<RaygunSettings setting="value"/>
+```
+
+**ThrowOnError**
+
+`type: bool`
+
+`default: false`
+
+This is false by default. Which means that any exception that occur within Raygun4Net itself will be silently caught. Setting this to true will allow any exceptions occurring in Raygun4Net to be thrown, which can help debug issues with Raygun4Net if crash reports aren't showing up in Raygun.
+
+
+**IgnoreSensitiveFieldNames**
+
+`type: string[]`
+
+`default: null`
+
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). `IgnoreSensitiveFieldNames` lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries in this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are explained in the `IsRawDataIgnored` section below).
+
+Setting `IgnoreSensitiveFieldNames` to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing `*` before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
+
+Individual options are also available which function in the same way as `IgnoreSensitiveFieldNames`: `IgnoreQueryParameterNames`, `IgnoreFormFieldNames`, `IgnoreHeaderNames`, `IgnoreCookieNames` and `IgnoreServerVariableNames`.
+
+The `IgnoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
+
+
+**IsRawDataIgnored**
+
+`type: bool`
+
+`default: false`
+
+By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. (Currently only supported in .NET Framework applications). If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set `IsRawDataIgnored` to true.
+
+If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the `IgnoreSensitiveFieldNames` options described above. You'll also need to specify how the fields should be stripped from the raw request payload. Set `UseXmlRawDataFilter` to true for XML payloads or/and set `UseKeyValuePairRawDataFilter` to true for payloads of the format "key1=value1&key2=value2".
+
+Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
+
+
+**CrashReportingOfflineStorageEnabled**
+
+`type: bool`
+
+`default: true`
+
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.

--- a/README.md
+++ b/README.md
@@ -14,154 +14,90 @@ Install the Serilog (if not included already) and Serilog.Sinks.Raygun package i
 
 ```bash
  dotnet add package Serilog
- dotnet add package Serilog.Sinks.Raygun 
+ dotnet add package Serilog.Sinks.Raygun
 ```
 
 ------
 
 ## Step 2 - Initialization
-There are two recommended options for initializing the Raygun Serilog Sink. Which option is best to use depends on the application. 
+The following examples are for .NET 6.0+ applications. For other frameworks, please refer to the [.NET Framework Readme](README-NET-FRAMEWORK.md).
 
-### Option 1 - Using logger configuration
-
-You can initialize Raygun's Serilog Sink through a Logger Configuration. This should be done inside of the main entry point of your application - for instance, Program.Main(), Global.asax, Application_Start Etc. The exact entry point will differ between frameworks.
-
-**Minimum setup example:**
-
-```cs
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Verbose()
-    .WriteTo.Raygun("paste_your_api_key_here")
-    .CreateLogger();
-```
-
-**Example setup with optional properties:**
+### Example of setup for ASP.NET Applications:
 ```csharp
+using Mindscape.Raygun4Net.AspNetCore;
+using Serilog;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add Raygun
+builder.Services.AddRaygun(builder.Configuration);
+builder.Services.AddRaygunUserProvider();
+
+builder.Host.UseSerilog((context, provider, config) =>
+{
+    // Add the Raygun sink
+    config.WriteTo.Raygun(raygunClient: provider.GetRequiredService<RaygunClient>());
+});
+```
+
+### Example of setup for Console/Service:
+```csharp
+using Mindscape.Raygun4Net;
+using Serilog;
+using Serilog.Sinks.Raygun.Extensions;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        // Add Raygun
+        services.AddRaygun(context.Configuration);
+        services.AddHostedService<Worker>();
+    })
+    .UseSerilog((_, serviceProvider, config) =>
+    {
+        // Add the Raygun sink
+        config.WriteTo.Raygun(raygunClient: serviceProvider.GetRequiredService<RaygunClient>());
+    })
+    .Build();
+
+await host.RunAsync();
+```
+
+### Example of setup for MAUI:
+```csharp
+using Serilog;
+
+var builder = MauiApp.CreateBuilder();
+
+builder
+    .UseMauiApp<App>()
+
+    // Add Raygun
+    .AddRaygun();
+
+var app = builder.Build();
+
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Verbose()
-    .WriteTo.Raygun("paste_your_api_key_here",
-      ListOfWrapperExceptions,
-      "CustomUserNameProperty",
-      "CustomAppVersionProperty",
-      LogEventLevel.Information,
-      CustomFormatProvider,
-      new[] { "globalTag1", "globalTag2" },
-      new[] { "ignoreField1", "ignoreField2" },
-      "CustomGroupKeyProperty",
-      "CustomTagsProperty",
-      "CustomUserInfoProperty",
-      onBeforeSendArguments => { /*OnBeforeSend: Action<onBeforeSendArguments>*/ })
+    .MinimumLevel.Debug()
+
+    // Add the Raygun sink
+    .WriteTo.Raygun(raygunClient: app.Services.GetRequiredService<RaygunMauiClient>())
     .CreateLogger();
-```
-------
 
-### Option 2 - Using the JSON configuration file
-You can initialize Raygun's Serilog Sink inside a Serilog JSON configuration file using the following examples.
-
-**Minimum setup example:**
-
-```json
-{
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Raygun"
-    ],
-    "WriteTo": [
-      {
-        "Name": "Raygun",
-        "Args": {
-          "applicationKey": "paste_your_api_key_here"
-        }
-      }
-    ]
-  }  
-}
-```
-
-**Example setup with optional properties:**
-```json
-{
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Raygun"
-    ],
-    "WriteTo": [
-      {
-        "Name": "Raygun",
-        "Args": {
-          "applicationKey": "paste_your_api_key_here",
-          "userNameProperty": "CustomUserNameProperty",
-          "applicationVersionProperty": "CustomAppVersionProperty",
-          "restrictedToMinimumLevel": "Error",
-          "ignoredFormFieldNames": ["ignoreField1", "ignoreField2"],
-          "tags": ["globalTag1", "globalTag2"],
-          "groupKeyProperty": "CustomGroupKeyProperty",
-          "tagsProperty": "CustomTagsProperty",
-          "userInfoProperty": "CustomUserInfoProperty"
-        }
-      }
-    ]
-  }  
-}
+return app;
 ```
 
 ----
 
 ## Configuration Properties
 
-**applicationKey**
+**raygunClient**
 
-`type: string`
+`type: RaygunClientBase`
 
 `required`
 
-Each application you create in Raygun will have an API key which you can pass in here to specify where the crash reports will be sent to. Although this is required, you can set this to null or empty string which would result in crash reports not being sent. This can be useful if you want to configure your local environment to not send crash reports to Raygun and then use config transforms or the like to provide an API key for other environments.
-
-**wrapperExceptions**
-
-`type: IEnumerable<Type>`
-
-`default: null`
-
-This is a list of wrapper exception types that you're not interested in logging to Raygun. Whenever an undesired wrapper exception is logged, it will be discarded and only the inner exception(s) will be logged.
-
-For example, you may not be interested in the details of an AggregateException, so you could include `typeof(AggregateException)` in this list of wrapperExceptions. All inner exceptions of any logged AggregateException would then be sent to Raygun as separate crash reports.
-
-
-**userNameProperty**
-
-`type: string`
-
-`default: UserName`
-
-This is so you can specify the username to log the information as a part of the crash report. By default it is UserName. You can set this to be to `null` if you do not want to use this feature.
-
-```cs
-Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random error"), "other information");
-```
-
-
-**applicationVersionProperty**
-
-`type: string`
-
-`default: ApplicationVersion`
-
-By default, crash reports sent to Raygun will have an ApplicationVersion field based on the version of the entry assembly for your application. If this is not being picked up correctly, or if you want to provide a different version, then you can do so by including the desired value in the logging properties collection.
-
-You can specify the property key that you place the version in by using this `applicationVersionProperty` setting. Otherwise the version will be read from the "ApplicationVersion" key.
-
-```cs
-Log.ForContext("CustomAppVersionProperty", "1.2.11").Error(new Exception("random error"), "other information");
-```
-
-**restrictedToMinimumLevel**
-
-`type: LogEventLevel`
-
-`default: LogEventLevel.Error`
-
-You can set the minimum log event level required in order to write an event to the sink. By default, this is set to Error as Raygun is mostly used for error reporting.
+This property is required for the Raygun Sink to function. The client can be any implementation that inherits from RaygunClientBase, this could be the Raygun4Maui client, Raygun4Net.AspNetCore client, or Raygun4Net.NetCore client. Ideally, this is resolved from the ServiceCollection in .NET Core applications.
 
 **formatProvider**
 
@@ -171,107 +107,14 @@ You can set the minimum log event level required in order to write an event to t
 
 This property supplies culture-specific formatting information. By default, it is null.
 
-**tags**
+**restrictedToMinimumLevel**
 
-`type: IEnumerable<string>`
+`type: LogEventLevel`
 
-`default: null`
+`default: LogEventLevel.Error`
 
-This is a list of global tags that will be included on every crash report sent with this Serilog sink.
+You can set the minimum log event level required in order to write an event to the sink. By default, this is set to Error as Raygun is mostly used for error reporting.
 
-
-**ignoredFormFieldNames**
-
-`type: IEnumerable<string>`
-
-`default: null`
-
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). This option lets you specify a list of form fields that you do not want to be sent to Raygun.
-
-Setting `ignoredFormFieldNames` to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
-
-Note that HTTP headers, query parameters, cookies, server variables and raw request data can also be filtered out. Configuration to do so is described in the [RaygunSettings](#raygun4net-features-configured-via-raygunsettings) section further below.
-
-The `ignoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
-
-
-**groupKeyProperty**
-
-`type: string`
-
-`default: GroupKey`
-
-Crash reports sent to Raygun will be automatically grouped together based on stack trace and exception type information. The `groupKeyProperty` setting specifies a key in the logging properties collection where you can provide a grouping key. Crash reports containing a grouping key will not be grouped automatically by Raygun. Instead, crash reports with matching custom grouping keys will be grouped together.
-
-```cs
-Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Exception("random error"), "other information");
-```
-
-
-**tagsProperty**
-
-`type: string`
-
-`default: Tags`
-
-This allows you to specify a key in the properties collection that contains a list of tags to include on crash reports. Note that these will be included in addition to any global tags [described above](#tags). If you set a list of tags in the properties collection multiple times (e.g. at different logging scopes) then only the latest list of tags will be used.
-
-```cs
-Log.ForContext("CustomTagsProperty", new[] {"tag1", "tag2"}).Error(new Exception("random error"), "other information");
-Log.Error(new Exception("random error"), "other information {@CustomTagsProperty}", new[] {"tag3", "tag4"});
-```
-
-**userInfoProperty**
-
-`type: string`
-
-`default: null`
-
-This is null by default, so you need to configure the `userInfoProperty` name if you want to log more user information in this way. This will cause the provided RaygunIdentifierMessage to be included in the "User" section of the Raygun payload, allowing the information to be picked up by the "Users" section of the Raygun service. It's recommended to destructure the RaygunIdentifierMessage, but this feature will still work if you don't. Sending user information in this way will overwrite the use of the `userNameProperty`.
-
-The user identifier passed into the RaygunIdentifierMessage constructor could be the users name, email address, database id or whatever works best for you to identify unique users.
-
-```cs
-var userInfo = new RaygunIdentifierMessage("12345")
-{
-    FirstName = "John",
-    FullName = "John Doe",
-    Email = "johndoe@email.address"
-};
-
-Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("random error"), "other information");
-```
-
-
-**onBeforeSend**
-
-`type: Action<OnBeforeSendParameters>`
-
-`default: null`
-
-This action allows you to manipulate the crash report payloads that get sent to Raygun. By default it is `null`, so you don't need to set it in the constructor. If the action is `null`, nothing happens; if an `Action<OnBeforeSendParameters>` is passed, it gets called just before the crash report payload gets serialized and sent to Raygun. The arguments to the action are of type `Struct OnBeforeSendArguments`; they are passed to the action when it is called and contain references to the following objects passed by the Raygun client object:
-
-```cs
-// Abstracted away version of the struct to just show the properties
-struct OnBeforeSendArguments
-{
-    System.Exception Exception;
-    Mindscape.Raygun4Net.Messages.RaygunMessage RaygunMessage;
-}
-```
-
-The provided action can read and/or modify their properties accordingly to produce the desired effect. For example, one can change the `MachineName` property in the `Details` of the `RaygunMessage` as follows:
-
- ```cs
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Verbose()
-    .WriteTo.Raygun(
-        applicationKey: "paste_your_api_key_here",
-        onBeforeSend: arguments => { 
-            arguments.RaygunMessage.Details.MachineName = "MyMachine";
-        })
-    .CreateLogger();
-```
 
 ------
 
@@ -281,68 +124,3 @@ Properties included from other Serilog Enrichers should automatically be include
 
 To use the old Raygun Enricher you can follow the [Enricher Readme](https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/README-ENRICHER.md) to add the enricher to your project.
 
-------
-
-## Raygun4Net features configured via RaygunSettings
-
-This sink wraps the [Raygun4Net](https://github.com/MindscapeHQ/raygun4net) provider to build a crash report from an Exception and send it to Raygun. This makes the following Raygun4Net features available to you. To use these features, you need to add RaygunSettings to your configuration as explained below which is separate to the Serilog configuration.
-
-
-**.NET Framework**
-
-Add the following section within the configSections element of your app.config or web.config file.
-
-```xml
-<section name="RaygunSettings" type="Mindscape.Raygun4Net.RaygunSettings, Mindscape.Raygun4Net"/>
-```
-
-Then add a RaygunSettings element containing the desired settings somewhere within the configuration element of the app.config or web.config file.
-
-```xml
-<RaygunSettings setting="value"/>
-```
-
-**ThrowOnError**
-
-`type: bool`
-
-`default: false`
-
-This is false by default. Which means that any exception that occur within Raygun4Net itself will be silently caught. Setting this to true will allow any exceptions occurring in Raygun4Net to be thrown, which can help debug issues with Raygun4Net if crash reports aren't showing up in Raygun.
-
-
-**IgnoreSensitiveFieldNames**
-
-`type: string[]`
-
-`default: null`
-
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). `IgnoreSensitiveFieldNames` lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries in this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are explained in the `IsRawDataIgnored` section below).
-
-Setting `IgnoreSensitiveFieldNames` to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing `*` before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
-
-Individual options are also available which function in the same way as `IgnoreSensitiveFieldNames`: `IgnoreQueryParameterNames`, `IgnoreFormFieldNames`, `IgnoreHeaderNames`, `IgnoreCookieNames` and `IgnoreServerVariableNames`.
-
-The `IgnoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
-
-
-**IsRawDataIgnored**
-
-`type: bool`
-
-`default: false`
-
-By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. (Currently only supported in .NET Framework applications). If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set `IsRawDataIgnored` to true.
-
-If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the `IgnoreSensitiveFieldNames` options described above. You'll also need to specify how the fields should be stripped from the raw request payload. Set `UseXmlRawDataFilter` to true for XML payloads or/and set `UseKeyValuePairRawDataFilter` to true for payloads of the format "key1=value1&key2=value2".
-
-Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
-
-
-**CrashReportingOfflineStorageEnabled**
-
-`type: bool`
-
-`default: true`
-
-Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.

--- a/Raygun.Serilog.sln
+++ b/Raygun.Serilog.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		LICENSE = LICENSE
 		README.md = README.md
 		README-ENRICHER.md = README-ENRICHER.md
+		README-NET-FRAMEWORK.md = README-NET-FRAMEWORK.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.SampleWebApp", "sampleApps\Serilog.Sinks.Raygun.SampleWebApp\Serilog.Sinks.Raygun.SampleWebApp.csproj", "{73E023EF-23CD-4450-AD12-6C37DC8ACB18}"

--- a/Raygun.Serilog.sln
+++ b/Raygun.Serilog.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.SampleWebApp", "sampleApps\Serilog.Sinks.Raygun.SampleWebApp\Serilog.Sinks.Raygun.SampleWebApp.csproj", "{73E023EF-23CD-4450-AD12-6C37DC8ACB18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.SampleServiceApp", "sampleApps\Serilog.Sinks.Raygun.SampleServiceApp\Serilog.Sinks.Raygun.SampleServiceApp.csproj", "{C9221450-8E8F-48DE-B1BF-8790CA3272DB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{73E023EF-23CD-4450-AD12-6C37DC8ACB18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73E023EF-23CD-4450-AD12-6C37DC8ACB18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73E023EF-23CD-4450-AD12-6C37DC8ACB18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9221450-8E8F-48DE-B1BF-8790CA3272DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9221450-8E8F-48DE-B1BF-8790CA3272DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9221450-8E8F-48DE-B1BF-8790CA3272DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9221450-8E8F-48DE-B1BF-8790CA3272DB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
@@ -22,17 +22,14 @@ Log.Logger = new LoggerConfiguration()
         // onBeforeSendArguments =>
         // {
         //     Console.Out.WriteLine("OnBeforeSend called with the following arguments: " + onBeforeSendArguments);
+        //
         //     //Updating machine name
         //     onBeforeSendArguments.RaygunMessage.Details.MachineName = "Serilog.Sinks.Raygun.SampleConsoleApp Machine";
         //
         //     //Testing throwing an exception in Action
         //     throw new Exception("Exception thrown in callback action..");
-        //     
         // }, 
-        settings: new RaygunSettings
-        {
-            //ApiEndpoint = new Uri("http://127.0.0.1:5000/entries")
-        })
+        settings: new RaygunSettings())
     .CreateLogger();
 
 try

--- a/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleConsoleApp/Program.cs
@@ -1,8 +1,10 @@
-﻿using Serilog;
+﻿using Mindscape.Raygun4Net;
+using Serilog;
 using Serilog.Events;
 
 Console.Out.WriteLine("Please enter your Raygun application key: ");
 var raygunApiKey = Console.In.ReadLine();
+
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Verbose()
@@ -17,15 +19,19 @@ Log.Logger = new LoggerConfiguration()
         "CustomGroupKeyProperty",
         "CustomTagsProperty",
         "CustomUserInfoProperty",
-        onBeforeSendArguments =>
+        // onBeforeSendArguments =>
+        // {
+        //     Console.Out.WriteLine("OnBeforeSend called with the following arguments: " + onBeforeSendArguments);
+        //     //Updating machine name
+        //     onBeforeSendArguments.RaygunMessage.Details.MachineName = "Serilog.Sinks.Raygun.SampleConsoleApp Machine";
+        //
+        //     //Testing throwing an exception in Action
+        //     throw new Exception("Exception thrown in callback action..");
+        //     
+        // }, 
+        settings: new RaygunSettings
         {
-            Console.Out.WriteLine("OnBeforeSend called with the following arguments: " + onBeforeSendArguments);
-            //Updating machine name
-            onBeforeSendArguments.RaygunMessage.Details.MachineName = "Serilog.Sinks.Raygun.SampleConsoleApp Machine";
-
-            //Testing throwing an exception in Action
-            throw new Exception("Exception thrown in callback action..");
-            
+            //ApiEndpoint = new Uri("http://127.0.0.1:5000/entries")
         })
     .CreateLogger();
 
@@ -42,6 +48,6 @@ catch (Exception e)
 Log.CloseAndFlush();
 
 //A Thread.Sleep is normally not necessary. Adding it here because the app is too small and there might not be enough time to send the errors to Raygun because of the asynchronous Send method used 
-Thread.Sleep(1000); 
+Thread.Sleep(1000);
 
 Console.Out.WriteLine("All done! Please check your Raygun App to ensure the two logged exceptions appear");

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Program.cs
@@ -1,0 +1,18 @@
+using Mindscape.Raygun4Net;
+using Serilog;
+using Serilog.Sinks.Raygun.Extensions;
+using Serilog.Sinks.Raygun.SampleServiceApp;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        services.AddRaygun(context.Configuration);
+        services.AddHostedService<Worker>();
+    })
+    .UseSerilog((_, serviceProvider, config) =>
+    {
+        config.WriteTo.Raygun(serviceProvider.GetRequiredService<RaygunClient>());
+    })
+    .Build();
+
+await host.RunAsync();

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Properties/launchSettings.json
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "Serilog.Sinks.Raygun.SampleServiceApp": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Serilog.Sinks.Raygun.SampleServiceApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Serilog.Sinks.Raygun.SampleServiceApp.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>dotnet-Serilog.Sinks.Raygun.SampleServiceApp-2443ca1d-bffb-4588-a819-f1bfc35c6170</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.0.4-pre-1" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.4-pre-1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1"/>
+        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj" />
+    </ItemGroup>
+</Project>

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Serilog.Sinks.Raygun.SampleServiceApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Serilog.Sinks.Raygun.SampleServiceApp.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.0.4-pre-1" />
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.4-pre-1" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.1.0" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.1.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1"/>
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Worker.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/Worker.cs
@@ -1,0 +1,23 @@
+namespace Serilog.Sinks.Raygun.SampleServiceApp;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+            
+            _logger.LogError(new Exception("This is an exception"), "This is an error message");
+
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+}

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/appsettings.Development.json
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/appsettings.json
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleServiceApp/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "RaygunSettings": {
+    "ApiKey": ""
+  }
+}

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Controllers/HomeController.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Controllers/HomeController.cs
@@ -49,6 +49,21 @@ public class HomeController : Controller
         return Content("HI");
     }
     
+    public IActionResult LogCritical()
+    {
+        try
+        {
+            throw new Exception("Serilog.Sinks.Raygun.SampleWebApp");
+        }
+        catch (Exception ex)
+        {
+            //_logger.LogCritical(ex, "Captured fatal error");
+            Log.Fatal(ex, "Logging fatal error");
+        }
+
+        return Content("HI");
+    }
+    
     public IActionResult ThrowWithUser()
     {
         // login user (faked)

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Controllers/HomeController.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Serilog.Sinks.Raygun.SampleWebApp.Models;
 
@@ -43,6 +44,28 @@ public class HomeController : Controller
         catch (Exception ex)
         {
             _logger.LogError(ex, "Captured an error");
+        }
+
+        return Content("HI");
+    }
+    
+    public IActionResult ThrowWithUser()
+    {
+        // login user (faked)
+        HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+        {
+            new(ClaimTypes.Name, "test"),
+            new(ClaimTypes.Email, "hello-world@banana.com"),
+            new(ClaimTypes.Role, "Admin")
+        }, "Test"));
+        
+        try
+        {
+            throw new Exception("An exception with a user i hope....");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Captured an error with custom data {Thing}", "Banana");
         }
 
         return Content("HI");

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Program.cs
@@ -1,10 +1,5 @@
-using Mindscape.Raygun4Net;
 using Mindscape.Raygun4Net.AspNetCore;
-
 using Serilog;
-using Serilog.Sinks.Raygun;
-using RaygunClient = Mindscape.Raygun4Net.AspNetCore.RaygunClient;
-using RaygunClientBase = Mindscape.Raygun4Net.RaygunClientBase;
 
 var apiKey = Environment.GetEnvironmentVariable("RAYGUN_APIKEY") ?? "";
 
@@ -12,9 +7,7 @@ Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .Enrich.With(new RaygunClientHttpEnricher())
     .WriteTo.Console()
-    //.WriteTo.Raygun(apiKey)
     .CreateLogger();
-
 
 try
 {
@@ -33,7 +26,6 @@ try
     });
 
     var app = builder.Build();
-
 
     // Configure the HTTP request pipeline.
     if (!app.Environment.IsDevelopment())

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Program.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Program.cs
@@ -1,9 +1,10 @@
+using Mindscape.Raygun4Net;
 using Mindscape.Raygun4Net.AspNetCore;
-using Mindscape.Raygun4Net.AspNetCore.Builders;
+
 using Serilog;
-using Serilog.Core;
-using Serilog.Events;
-using RaygunSettings = Mindscape.Raygun4Net.AspNetCore.RaygunSettings;
+using Serilog.Sinks.Raygun;
+using RaygunClient = Mindscape.Raygun4Net.AspNetCore.RaygunClient;
+using RaygunClientBase = Mindscape.Raygun4Net.RaygunClientBase;
 
 var apiKey = Environment.GetEnvironmentVariable("RAYGUN_APIKEY") ?? "";
 
@@ -11,8 +12,9 @@ Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .Enrich.With(new RaygunClientHttpEnricher())
     .WriteTo.Console()
-    .WriteTo.Raygun(apiKey)
+    //.WriteTo.Raygun(apiKey)
     .CreateLogger();
+
 
 try
 {
@@ -22,7 +24,13 @@ try
     builder.Services.AddControllersWithViews();
     builder.Services.AddHttpContextAccessor();
 
-    builder.Host.UseSerilog();
+    builder.Services.AddRaygun(builder.Configuration);
+    builder.Services.AddRaygunUserProvider();
+
+    builder.Host.UseSerilog((context, provider, config) =>
+    {
+        config.WriteTo.Raygun(raygunClient: provider.GetRequiredService<RaygunClient>());
+    });
 
     var app = builder.Build();
 
@@ -55,64 +63,4 @@ catch (Exception e)
 finally
 {
     Log.CloseAndFlush();
-}
-
-
-public class RaygunClientHttpEnricher : ILogEventEnricher
-{
-    private const string RaygunRequestMessagePropertyName = "RaygunSink_RequestMessage";
-    private const string RaygunResponseMessagePropertyName = "RaygunSink_ResponseMessage";
-
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly LogEventLevel _restrictedToMinimumLevel;
-    private readonly RaygunRequestMessageOptions _messageOptions; 
-
-    public RaygunClientHttpEnricher(IHttpContextAccessor? httpContextAccessor = null, LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error, RaygunSettings? raygunSettings = null)
-    {
-        _httpContextAccessor = httpContextAccessor ?? new HttpContextAccessor();
-        _restrictedToMinimumLevel = restrictedToMinimumLevel;
-        
-        var settings = raygunSettings ?? new RaygunSettings();
-        
-        _messageOptions = new RaygunRequestMessageOptions
-        {
-            IsRawDataIgnored = settings.IsRawDataIgnored,
-            UseXmlRawDataFilter = settings.UseXmlRawDataFilter,
-            IsRawDataIgnoredWhenFilteringFailed = settings.IsRawDataIgnoredWhenFilteringFailed,
-            UseKeyValuePairRawDataFilter = settings.UseKeyValuePairRawDataFilter
-        };
-
-        _messageOptions.AddCookieNames(settings.IgnoreCookieNames ?? Array.Empty<string>());
-        _messageOptions.AddHeaderNames(settings.IgnoreHeaderNames ?? Array.Empty<string>());
-        _messageOptions.AddFormFieldNames(settings.IgnoreFormFieldNames ?? Array.Empty<string>());
-        _messageOptions.AddQueryParameterNames(settings.IgnoreQueryParameterNames ?? Array.Empty<string>());
-        _messageOptions.AddSensitiveFieldNames(settings.IgnoreSensitiveFieldNames ?? Array.Empty<string>());
-        _messageOptions.AddServerVariableNames(settings.IgnoreServerVariableNames ?? Array.Empty<string>());
-    }
-
-    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-    {
-        if (logEvent.Level < _restrictedToMinimumLevel)
-        {
-            return;
-        }
-
-        if (_httpContextAccessor.HttpContext == null)
-        {
-            return;
-        }
-
-        var httpRequestMessage = RaygunAspNetCoreRequestMessageBuilder
-            .Build(_httpContextAccessor.HttpContext, _messageOptions)
-            .GetAwaiter()
-            .GetResult();
-
-        var httpResponseMessage = RaygunAspNetCoreResponseMessageBuilder.Build(_httpContextAccessor.HttpContext);
-
-        // The Raygun request/response messages are stored in the logEvent properties collection.
-        // When the error is sent to Raygun, these messages are extracted from the known properties
-        // and then removed so as to not duplicate data in the payload.
-        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(RaygunRequestMessagePropertyName, httpRequestMessage, true));
-        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(RaygunResponseMessagePropertyName, httpResponseMessage, true));
-    }
 }

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/RaygunClientHttpEnricher.cs
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/RaygunClientHttpEnricher.cs
@@ -1,16 +1,8 @@
-## ASP.NET Core Enricher
+﻿using Mindscape.Raygun4Net.AspNetCore;
+using Mindscape.Raygun4Net.AspNetCore.Builders;
+using Serilog.Core;
+using Serilog.Events;
 
-With the release of v7.3.0, the ASP.NET Core Enricher has been removed from this package. 
-This is because the enricher had a dependency on `Mindscape.Raygun4Net.AspNetCore`, which in turn had a dependency
-on `Microsoft.AspNetCore.App`. Attempting to use `Serilog.Sinks.Raygun` in a MAUI app would result in an error.
-
-If you still wish to use the enricher you can follow the steps outlined below.
-
-### Create a new Enricher class
-
-Note: You will need to include a dependency on [Mindscape.Raygun4Net.AspNetCore](https://www.nuget.org/packages/Mindscape.Raygun4Net.AspNetCore) for this to work.
-
-```c#
 public class RaygunClientHttpEnricher : ILogEventEnricher
 {
     private const string RaygunRequestMessagePropertyName = "RaygunSink_RequestMessage";
@@ -54,26 +46,3 @@ public class RaygunClientHttpEnricher : ILogEventEnricher
         logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(RaygunResponseMessagePropertyName, httpResponseMessage, true));
     }
 }
-```
-
-### Include the enricher into Serilog configuration
-
-Please note, this an example configuration to show the use of `Enrich.With(...)`
-```c#
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
-    .Enrich.With(new RaygunClientHttpEnricher())
-    .WriteTo.Console()
-    .WriteTo.Raygun("*your api key*")
-    .CreateLogger();
-```
-
-### Ensure HttpContextAccessor is registered with the DI container
-
-When setting up the DI container, ensure that the `HttpContextAccessor` is registered.
-
-```c#
-services.AddHttpContextAccessor();
-```
-
-When errors are thrown they should now contain the original information from the Raygun Enricher.

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
@@ -4,10 +4,12 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Version>2.3.4.5</Version>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="8.2.0" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.0.4-pre-1" />
+        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="11.0.4-pre-1" />
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     </ItemGroup>

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/Serilog.Sinks.Raygun.SampleWebApp.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.0.4-pre-1" />
-        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="11.0.4-pre-1" />
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore.Common" Version="11.1.0" />
+        <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="11.1.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     </ItemGroup>

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/appsettings.json
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/appsettings.json
@@ -5,5 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RaygunSettings": {
+  }
 }

--- a/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/appsettings.json
+++ b/sampleApps/Serilog.Sinks.Raygun.SampleWebApp/appsettings.json
@@ -7,5 +7,6 @@
   },
   "AllowedHosts": "*",
   "RaygunSettings": {
+    "ApiKey": "zqpKCLNE8SXj7aBfjZv98w"
   }
 }

--- a/src/Serilog.Sinks.Raygun/ApplicationBuilderExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/ApplicationBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿#if NET
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Mindscape.Raygun4Net;
+
+// ReSharper disable once CheckNamespace
+namespace Serilog.Sinks.Raygun.Extensions;
+
+public static class ApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Registers the Raygun Client and Raygun Settings with the DI container. Settings will be fetched from the appsettings.json file,
+    /// and can be overridden by providing a custom configuration delegate.
+    /// </summary>
+    public static IServiceCollection AddRaygun(this IServiceCollection services, IConfiguration configuration, Action<RaygunSettings>? options = null)
+    {
+        // Fetch settings from configuration or use default settings
+        var settings = configuration.GetSection("RaygunSettings").Get<RaygunSettings>() ?? new RaygunSettings();
+    
+        // Override settings with user-provided settings
+        options?.Invoke(settings);
+
+        services.TryAddSingleton(settings);
+        services.TryAddSingleton(s => new RaygunClient(s.GetService<RaygunSettings>()!, s.GetService<IRaygunUserProvider>()!));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Raygun Client and Raygun Settings with the DI container. Settings will be defaulted and overridden by providing a custom configuration delegate.
+    /// </summary>
+    public static IServiceCollection AddRaygun(this IServiceCollection services, Action<RaygunSettings>? options)
+    {
+        // Since we are not using IConfiguration, we need to create a new instance of RaygunSettings
+        var settings = new RaygunSettings();
+    
+        // Override settings with user-provided settings
+        options?.Invoke(settings);
+    
+        services.TryAddSingleton(settings);
+        services.TryAddSingleton(s => new RaygunClient(s.GetService<RaygunSettings>()!, s.GetService<IRaygunUserProvider>()!));
+
+        return services;
+    }
+}
+
+#endif

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -104,7 +104,7 @@ public static class LoggerConfigurationRaygunExtensions
         IEnumerable<string> tags = null,
         LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error)
     {
-        return loggerConfiguration.Sink(new RaygunSinkV2(raygunClient, formatProvider, tags), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new RaygunClientSink(raygunClient, formatProvider, tags), restrictedToMinimumLevel);
     }
 #endif
 }

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -33,9 +33,9 @@ public static class LoggerConfigurationRaygunExtensions
     /// <param name="loggerConfiguration">The logger configuration.</param>
     /// <param name="applicationKey">The application key as found on an application in your Raygun account.</param>
     /// <param name="wrapperExceptions">If you have common outer exceptions that wrap a valuable inner exception which you'd prefer to group by, you can specify these by providing a list.</param>
-    /// <param name="userNameProperty">Specifies the property name to read the username from. By default it is UserName. Set to null if you do not want to use this feature.</param>
+    /// <param name="userNameProperty">Specifies the property name to read the username from. By default, it is UserName. Set to null if you do not want to use this feature.</param>
     /// <param name="applicationVersionProperty">Specifies the property to use to retrieve the application version from. You can use an enricher to add the application version to all the log events. When you specify null, Raygun will use the assembly version.</param> 
-    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. By default set to Error as Raygun is mostly used for error reporting.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. By default, set to Error as Raygun is mostly used for error reporting.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
     /// <param name="ignoredFormFieldNames">Specifies the form field names which to ignore when including request form data.</param>
@@ -84,4 +84,27 @@ public static class LoggerConfigurationRaygunExtensions
             settings,
             raygunClientProvider), restrictedToMinimumLevel);
     }
+
+#if NET
+    /// <summary>
+    /// Adds a sink that writes log events (defaults to error and up) to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
+    /// Your message is part of the custom data.
+    /// </summary>
+    /// <param name="loggerConfiguration">The logger configuration.</param>
+    /// <param name="raygunClient">Instance of RaygunClient which should be passed in by resolving from a DI container or a static instance.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param> 
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. By default, set to Error as Raygun is mostly used for error reporting.</param>
+    /// <returns>Logger configuration, allowing configuration to continue.</returns>
+    /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+    // This sink only exists for .NET Core as it is intended to be used with DI.
+    public static LoggerConfiguration Raygun(this LoggerSinkConfiguration loggerConfiguration,
+        RaygunClientBase raygunClient,
+        IFormatProvider formatProvider = null,
+        IEnumerable<string> tags = null,
+        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error)
+    {
+        return loggerConfiguration.Sink(new RaygunSinkV2(raygunClient, formatProvider, tags), restrictedToMinimumLevel);
+    }
+#endif
 }

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -19,8 +19,8 @@
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>7.5.0</VersionPrefix>
-        <PackageVersion>7.5.0-pre-1</PackageVersion>
+        <VersionPrefix>7.6.0</VersionPrefix>
+        <PackageVersion>7.6.0-pre-1</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 
@@ -28,11 +28,11 @@
                           '$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="8.2.0"/>
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.4-pre-1"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <PackageReference Include="Mindscape.Raygun4Net" Version="8.0.0"/>
+        <PackageReference Include="Mindscape.Raygun4Net" Version="11.0.4-pre-1"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
     </ItemGroup>
 

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -29,6 +29,8 @@
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.4-pre-1"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -28,13 +28,13 @@
                           '$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.0.4-pre-1"/>
+        <PackageReference Include="Mindscape.Raygun4Net.NetCore" Version="11.1.0"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <PackageReference Include="Mindscape.Raygun4Net" Version="11.0.4-pre-1"/>
+        <PackageReference Include="Mindscape.Raygun4Net" Version="11.1.0"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3"/>
     </ItemGroup>
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
@@ -8,13 +8,13 @@ public static class LogEventPropertyExtensions
 {
     public static string AsString(this LogEventPropertyValue propertyValue)
     {
-        if (!(propertyValue is ScalarValue scalar))
+        if (propertyValue is not ScalarValue scalar)
         {
             return null;
         }
 
         // Handle string values differently as the ToString() method will wrap the string in unwanted quotes
-        return scalar.Value is string s ? s : scalar.ToString();
+        return scalar.Value as string ?? scalar.ToString();
     }
 
     public static string AsString(this LogEventProperty property)
@@ -31,18 +31,17 @@ public static class LogEventPropertyExtensions
             return defaultIfNull;
         }
 
-        return int.TryParse(property.Value.AsString(), out int result) ? result : defaultIfNull;
+        return int.TryParse(property.Value.AsString(), out var result) ? result : defaultIfNull;
     }
 
     public static IDictionary AsDictionary(this LogEventProperty property)
     {
-        if (!(property.Value is DictionaryValue value))
+        if (property.Value is not DictionaryValue value)
         {
             return null;
         }
 
-        return value.Elements.ToDictionary(
-            kv => kv.Key.AsString(),
+        return value.Elements.ToDictionary(kv => kv.Key.AsString(),
             kv => kv.Value is ScalarValue scalarValue ? scalarValue.Value : kv.Value);
     }
 }

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.Raygun;
 /// <summary>
 /// RaygunSink for Serilog which handles logging to Raygun.
 /// </summary>
-public class RaygunSinkV2 : ILogEventSink
+public class RaygunClientSink : ILogEventSink
 {
     private const string RenderedLogMessageProperty = "RenderedLogMessage";
     private const string LogMessageTemplateProperty = "LogMessageTemplate";
@@ -34,7 +34,7 @@ public class RaygunSinkV2 : ILogEventSink
     /// <param name="raygunClient">Instance of RaygunClient which should be passed in by resolving from a DI container or a static instance.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
-    public RaygunSinkV2(RaygunClientBase raygunClient,
+    public RaygunClientSink(RaygunClientBase raygunClient,
         IFormatProvider? formatProvider = null,
         IEnumerable<string>? tags = null
     )

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunPropertyFormatter.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunPropertyFormatter.cs
@@ -26,17 +26,16 @@ namespace Serilog.Sinks.Raygun;
 /// </summary>
 internal static class RaygunPropertyFormatter
 {
-    private static readonly HashSet<Type> RaygunScalars = new()
-    {
+    private static readonly HashSet<Type> RaygunScalars =
+    [
         typeof(bool),
         typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
         typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal),
         typeof(byte[])
-    };
+    ];
 
     /// <summary>
-    /// Simplify the object so as to make handling the serialized
-    /// representation easier.
+    /// Simplify the object to make handling the serialized representation easier.
     /// </summary>
     /// <param name="value">The value to simplify (possibly null).</param>
     /// <returns>A simplified representation.</returns>

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -165,7 +165,12 @@ public class RaygunSink : ILogEventSink
         // Submit
         if (logEvent.Level == LogEventLevel.Fatal)
         {
+#if NETFRAMEWORK
             client.Send(exception, tags, properties);
+#else
+            // Fail is prob going to crash the app so let's try to send the log to raygun synchronously
+            client.SendAsync(exception, tags, properties).GetAwaiter().GetResult();
+#endif
         }
         else
         {

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -48,7 +48,6 @@ public class RaygunSink : ILogEventSink
     private readonly string _userInfoProperty;
     private readonly Action<OnBeforeSendArguments> _onBeforeSend;
     private readonly IEnumerable<Type> _wrapperExceptions;
-    //private readonly IEnumerable<string> _ignoredFormFieldNames;
 
     private readonly RaygunSettings _settings;
     private readonly IRaygunClientProvider _raygunClientProvider;
@@ -93,7 +92,6 @@ public class RaygunSink : ILogEventSink
         _userInfoProperty = userInfoProperty;
         _onBeforeSend = onBeforeSend;
         _wrapperExceptions = wrapperExceptions;
-        //_ignoredFormFieldNames = ignoredFormFieldNames;
 
         _settings = settings ?? new RaygunSettings
         {
@@ -121,12 +119,6 @@ public class RaygunSink : ILogEventSink
         {
             client.AddWrapperExceptions(_wrapperExceptions.ToArray());
         }
-
-        // TODO: Figure out how we can 'ignore' form field names on mobile platforms
-        // if (_ignoredFormFieldNames != null)
-        // {
-        //     client.IgnoreFormFieldNames(_ignoredFormFieldNames.ToArray());
-        // }
 
         client.CustomGroupingKey += OnCustomGroupingKey;
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSinkV2.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSinkV2.cs
@@ -71,7 +71,7 @@ public class RaygunSinkV2 : ILogEventSink
         // Submit
         if (logEvent.Level == LogEventLevel.Fatal)
         {
-            // Fail is prob going to crash the app so let's try to send the log to raygun synchronously
+            // Fatal is prob going to crash the app so let's try to send the log to raygun synchronously
             _raygunClient.SendAsync(exception, tags, properties).GetAwaiter().GetResult();
         }
         else

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSinkV2.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSinkV2.cs
@@ -1,0 +1,225 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Serilog.Core;
+using Serilog.Events;
+using Mindscape.Raygun4Net;
+
+namespace Serilog.Sinks.Raygun;
+
+#if NET
+/// <summary>
+/// RaygunSink for Serilog which handles logging to Raygun.
+/// </summary>
+public class RaygunSinkV2 : ILogEventSink
+{
+    private const string RenderedLogMessageProperty = "RenderedLogMessage";
+    private const string LogMessageTemplateProperty = "LogMessageTemplate";
+    private const string OccurredProperty = "RaygunSink_OccurredOn";
+    private const string RaygunRequestMessagePropertyName = "RaygunSink_RequestMessage";
+    private const string RaygunResponseMessagePropertyName = "RaygunSink_ResponseMessage";
+
+    private readonly IFormatProvider? _formatProvider;
+    private readonly IEnumerable<string> _tags;
+
+    private readonly RaygunClientBase _raygunClient;
+
+    /// <summary>
+    /// Construct a sink that saves errors to the Raygun service. Properties and the log message are being attached as UserCustomData and the level is included as a Tag.
+    /// </summary>
+    /// <param name="raygunClient">Instance of RaygunClient which should be passed in by resolving from a DI container or a static instance.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
+    public RaygunSinkV2(RaygunClientBase raygunClient,
+        IFormatProvider? formatProvider = null,
+        IEnumerable<string>? tags = null
+    )
+    {
+        _raygunClient = raygunClient;
+        _formatProvider = formatProvider;
+        _tags = tags ?? Array.Empty<string>();
+        
+        _raygunClient.CustomGroupingKey += OnCustomGroupingKey;
+
+        // Raygun4Net adds these two wrapper exceptions by default, but as there is no way to remove them through this Serilog sink, we replace them entirely with the configured wrapper exceptions.
+        _raygunClient.RemoveWrapperExceptions(typeof(TargetInvocationException),
+            Type.GetType("System.Web.HttpUnhandledException, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
+    }
+
+    /// <summary>
+    /// Emit the provided log event to the sink.
+    /// </summary>
+    /// <param name="logEvent">The log event to write.</param>
+    public void Emit(LogEvent logEvent)
+    {
+        // Include the log level as a tag.
+        var tags = _tags.Concat(new[] { logEvent.Level.ToString() }).ToList();
+        var properties = logEvent.Properties.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        // Add the message and template to the properties
+        properties[RenderedLogMessageProperty] = new ScalarValue(logEvent.RenderMessage(_formatProvider));
+        properties[LogMessageTemplateProperty] = new ScalarValue(logEvent.MessageTemplate.Text);
+        properties[OccurredProperty] = new ScalarValue(logEvent.Timestamp.UtcDateTime);
+
+        // Decide what exception object to send
+        var exception = logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace());
+
+        // Submit
+        if (logEvent.Level == LogEventLevel.Fatal)
+        {
+            // Fail is prob going to crash the app so let's try to send the log to raygun synchronously
+            _raygunClient.SendAsync(exception, tags, properties).GetAwaiter().GetResult();
+        }
+        else
+        {
+            // Discard the task, we don't care about the result
+            _ = _raygunClient.SendInBackground(exception, tags, properties);
+        }
+    }
+
+    private void OnCustomGroupingKey(object? sender, RaygunCustomGroupingKeyEventArgs e)
+    {
+        if (e.Message?.Details != null)
+        {
+            var details = e.Message.Details;
+    
+            details.Client = new RaygunClientMessage
+            {
+                Name = "RaygunSerilogSink",
+                Version = GetType().Assembly.GetName().Version?.ToString() ?? string.Empty,
+                ClientUrl = "https://github.com/serilog/serilog-sinks-raygun"
+            };
+    
+            if (details.UserCustomData is Dictionary<string, LogEventPropertyValue> properties)
+            {
+                // If an Exception has not been provided, then use the log message/template to fill in the details and attach the current execution stack
+                if (e.Exception is NullException nullException)
+                {
+                    details.Error = new RaygunErrorMessage
+                    {
+                        ClassName = properties[LogMessageTemplateProperty].AsString(),
+                        Message = properties[RenderedLogMessageProperty].AsString(),
+                        StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
+                    };
+                }
+    
+                if (properties.TryGetValue(OccurredProperty, out var occurredOnPropertyValue) &&
+                    occurredOnPropertyValue is ScalarValue { Value: DateTime occurredOn })
+                {
+                    e.Message.OccurredOn = occurredOn;
+    
+                    properties.Remove(OccurredProperty);
+                }
+    
+                // Add Http request/response messages if present and not already set
+                if (details.Request == null &&
+                    properties.TryGetValue(RaygunRequestMessagePropertyName, out var requestMessageProperty) &&
+                    requestMessageProperty is StructureValue requestMessageValue)
+                {
+                    details.Request = BuildRequestMessageFromStructureValue(requestMessageValue);
+                    properties.Remove(RaygunRequestMessagePropertyName);
+                }
+    
+                if (details.Response == null &&
+                    properties.TryGetValue(RaygunResponseMessagePropertyName, out var responseMessageProperty) &&
+                    responseMessageProperty is StructureValue responseMessageValue)
+                {
+                    details.Response = BuildResponseMessageFromStructureValue(responseMessageValue);
+                    properties.Remove(RaygunResponseMessagePropertyName);
+                }
+    
+                // Simplify the remaining properties to be used as user-custom-data
+                details.UserCustomData = properties
+                    .Select(pv => new { Name = pv.Key, Value = RaygunPropertyFormatter.Simplify(pv.Value) })
+                    .ToDictionary(a => a.Name, b => b.Value);
+            }
+        }
+    }
+
+    private static StackTrace GetCurrentExecutionStackTrace()
+    {
+        var stackTrace = new StackTrace();
+
+        for (var frameIndex = 0; frameIndex < stackTrace.FrameCount; frameIndex++)
+        {
+            var method = stackTrace.GetFrame(frameIndex)?.GetMethod();
+            var className = method?.ReflectedType?.FullName ?? "";
+
+            if (!className.StartsWith("Serilog."))
+            {
+                return new StackTrace(frameIndex);
+            }
+        }
+
+        return stackTrace;
+    }
+
+    private static RaygunResponseMessage BuildResponseMessageFromStructureValue(StructureValue responseMessageStructure)
+    {
+        var responseMessage = new RaygunResponseMessage();
+
+        foreach (var property in responseMessageStructure.Properties)
+        {
+            switch (property.Name)
+            {
+                case nameof(RaygunResponseMessage.Content):
+                    responseMessage.Content = property.AsString();
+                    break;
+                case nameof(RaygunResponseMessage.StatusCode):
+                    responseMessage.StatusCode = property.AsInteger();
+                    break;
+                case nameof(RaygunResponseMessage.StatusDescription):
+                    responseMessage.StatusDescription = property.AsString();
+                    break;
+            }
+        }
+
+        return responseMessage;
+    }
+
+    private static RaygunRequestMessage BuildRequestMessageFromStructureValue(StructureValue requestMessageStructure)
+    {
+        var requestMessage = new RaygunRequestMessage();
+
+        foreach (var property in requestMessageStructure.Properties)
+        {
+            switch (property.Name)
+            {
+                case nameof(RaygunRequestMessage.Url):
+                    requestMessage.Url = property.AsString();
+                    break;
+                case nameof(RaygunRequestMessage.HostName):
+                    requestMessage.HostName = property.AsString();
+                    break;
+                case nameof(RaygunRequestMessage.HttpMethod):
+                    requestMessage.HttpMethod = property.AsString();
+                    break;
+                case nameof(RaygunRequestMessage.IPAddress):
+                    requestMessage.IPAddress = property.AsString();
+                    break;
+                case nameof(RaygunRequestMessage.RawData):
+                    requestMessage.RawData = property.AsString();
+                    break;
+                case nameof(RaygunRequestMessage.Headers):
+                    requestMessage.Headers = property.AsDictionary();
+                    break;
+                case nameof(RaygunRequestMessage.QueryString):
+                    requestMessage.QueryString = property.AsDictionary();
+                    break;
+                case nameof(RaygunRequestMessage.Form):
+                    requestMessage.Form = property.AsDictionary();
+                    break;
+                case nameof(RaygunRequestMessage.Data):
+                    requestMessage.Data = property.AsDictionary();
+                    break;
+            }
+        }
+
+        return requestMessage;
+    }
+}
+#endif


### PR DESCRIPTION
Previously you would need to create a custom provider to resolve the RaygunClient, but registering the sink requires a string ApiKey parameter, this made registration a bit fiddly and verbose.

The new Sink registration allows for the following configurations to be done:

### Example of setup for ASP.NET Applications:
```csharp
using Mindscape.Raygun4Net.AspNetCore;
using Serilog;

var builder = WebApplication.CreateBuilder(args);

// Add Raygun
builder.Services.AddRaygun(builder.Configuration);
builder.Services.AddRaygunUserProvider();

builder.Host.UseSerilog((context, provider, config) =>
{
    // Add the Raygun sink
    config.WriteTo.Raygun(raygunClient: provider.GetRequiredService<RaygunClient>());
});
```

### Example of setup for Console/Service:
```csharp
using Mindscape.Raygun4Net;
using Serilog;
using Serilog.Sinks.Raygun.Extensions;

var host = Host.CreateDefaultBuilder(args)
    .ConfigureServices((context, services) =>
    {
        // Add Raygun
        services.AddRaygun(context.Configuration);
        services.AddHostedService<Worker>();
    })
    .UseSerilog((_, serviceProvider, config) =>
    {
        // Add the Raygun sink
        config.WriteTo.Raygun(raygunClient: serviceProvider.GetRequiredService<RaygunClient>());
    })
    .Build();

await host.RunAsync();
```

### Example of setup for MAUI:
```csharp
using Serilog;

var builder = MauiApp.CreateBuilder();

builder
    .UseMauiApp<App>()

    // Add Raygun
    .AddRaygun();

var app = builder.Build();

Log.Logger = new LoggerConfiguration()
    .MinimumLevel.Debug()

    // Add the Raygun sink
    .WriteTo.Raygun(raygunClient: app.Services.GetRequiredService<RaygunMauiClient>())
    .CreateLogger();

return app;
```