### PR TITLE
Added new optional argument to send errors with no exception

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,10 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
+### v8.1.0
+- Added flag for .NET Core Sink to allow/disallow Error Logs with no Exception being sent to Raygun
+  - This is to allow for more control over what is sent to Raygun
+  - Default is false and will not send Error Logs that have no exception to Raygun
+  - See:
 
 ### v8.0.0
 - Updated Raygun4Net dependency

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -4,7 +4,7 @@
 - Added flag for .NET Core Sink to allow/disallow Error Logs with no Exception being sent to Raygun
   - This is to allow for more control over what is sent to Raygun
   - Default is false and will not send Error Logs that have no exception to Raygun
-  - See:
+  - See: https://github.com/MindscapeHQ/serilog-sinks-raygun/pull/72
 
 ### v8.0.0
 - Updated Raygun4Net dependency

--- a/src/Serilog.Sinks.Raygun/ApplicationBuilderExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#if NET
+#nullable enable
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -95,6 +95,7 @@ public static class LoggerConfigurationRaygunExtensions
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param> 
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. By default, set to Error as Raygun is mostly used for error reporting.</param>
+    /// <param name="logWithoutException">Allows error logs without an Exception to be sent to Raygun.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     // This sink only exists for .NET Core as it is intended to be used with DI.
@@ -102,9 +103,10 @@ public static class LoggerConfigurationRaygunExtensions
         RaygunClientBase raygunClient,
         IFormatProvider formatProvider = null,
         IEnumerable<string> tags = null,
-        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error)
+        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error,
+        bool logWithoutException = false)
     {
-        return loggerConfiguration.Sink(new RaygunClientSink(raygunClient, formatProvider, tags), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new RaygunClientSink(raygunClient, formatProvider, tags, logWithoutException), restrictedToMinimumLevel);
     }
 #endif
 }

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <OutputType>Library</OutputType>
         
@@ -15,16 +15,16 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
         <PackageTags>serilog;sink;raygun;crash;exception-handling;exception-reporting;exception-handler;unhandled-exceptions;debugging;debug;bug;bugs;exceptions;error;errors;crash-reporting;aspnet-core</PackageTags>
-        <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
+        <Copyright>Copyright © Serilog Contributors 2017-2025</Copyright>
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>7.6.0</VersionPrefix>
-        <PackageVersion>7.6.0-pre-1</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' or 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' or
+                          '$(TargetFramework)' == 'net8.0' or 
+                          '$(TargetFramework)' == 'net7.0' or 
                           '$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
@@ -24,6 +24,7 @@ public class RaygunClientSink : ILogEventSink
     private const string RaygunResponseMessagePropertyName = "RaygunSink_ResponseMessage";
 
     private readonly IFormatProvider? _formatProvider;
+    private readonly bool _logWithoutException;
     private readonly IEnumerable<string> _tags;
 
     private readonly RaygunClientBase _raygunClient;
@@ -34,13 +35,16 @@ public class RaygunClientSink : ILogEventSink
     /// <param name="raygunClient">Instance of RaygunClient which should be passed in by resolving from a DI container or a static instance.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
+    /// <param name="logWithoutException">Allows error logs without an Exception to be sent to Raygun.</param>
     public RaygunClientSink(RaygunClientBase raygunClient,
         IFormatProvider? formatProvider = null,
-        IEnumerable<string>? tags = null
+        IEnumerable<string>? tags = null,
+        bool logWithoutException = false
     )
     {
         _raygunClient = raygunClient;
         _formatProvider = formatProvider;
+        _logWithoutException = logWithoutException;
         _tags = tags ?? Array.Empty<string>();
         
         _raygunClient.CustomGroupingKey += OnCustomGroupingKey;
@@ -56,8 +60,14 @@ public class RaygunClientSink : ILogEventSink
     /// <param name="logEvent">The log event to write.</param>
     public void Emit(LogEvent logEvent)
     {
+        // If there is no exception, and we are not logging without exception, then we don't want to send the log to Raygun.
+        if (logEvent.Exception == null && !_logWithoutException)
+        {
+            return;
+        }
+        
         // Include the log level as a tag.
-        var tags = _tags.Concat(new[] { logEvent.Level.ToString() }).ToList();
+        var tags = _tags.Concat([logEvent.Level.ToString()]).ToList();
         var properties = logEvent.Properties.ToDictionary(kv => kv.Key, kv => kv.Value);
 
         // Add the message and template to the properties

--- a/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
+++ b/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
-		<TargetFrameworks>net6.0;net462</TargetFrameworks>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
When errors are logged with `.LogError` or equivalent, with no `Exception`, the ASP.NET middleware picks up 500 errors and ships those off to Raygun, this is causing duplicate errors to be raised.

New parameter makes this opt in.