### PR TITLE
RaygunClientSink - Add support for tags from emitted log event properties

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,6 +1,6 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
-### v8.1.0
+### v8.2.0
 - Updated `RaygunClientSink` to support extracting "Tags" from emitted log event properties
 - See: https://github.com/MindscapeHQ/serilog-sinks-raygun/pull/73
 

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Full Change Log for Serilog.Sinks.Raygun package
 
+### v8.1.0
+- Updated `RaygunClientSink` to support extracting "Tags" from emitted log event properties
+- See: https://github.com/MindscapeHQ/serilog-sinks-raygun/pull/73
 
 ### v8.0.0
 - Updated Raygun4Net dependency

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -95,6 +95,7 @@ public static class LoggerConfigurationRaygunExtensions
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param> 
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. By default, set to Error as Raygun is mostly used for error reporting.</param>
+    /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     // This sink only exists for .NET Core as it is intended to be used with DI.
@@ -102,9 +103,10 @@ public static class LoggerConfigurationRaygunExtensions
         RaygunClientBase raygunClient,
         IFormatProvider formatProvider = null,
         IEnumerable<string> tags = null,
-        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error)
+        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error,
+        string tagsProperty = "Tags")
     {
-        return loggerConfiguration.Sink(new RaygunClientSink(raygunClient, formatProvider, tags), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new RaygunClientSink(raygunClient, formatProvider, tags, tagsProperty), restrictedToMinimumLevel);
     }
 #endif
 }

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;net462;netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <OutputType>Library</OutputType>
         
@@ -15,7 +15,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
         <PackageTags>serilog;sink;raygun;crash;exception-handling;exception-reporting;exception-handler;unhandled-exceptions;debugging;debug;bug;bugs;exceptions;error;errors;crash-reporting;aspnet-core</PackageTags>
-        <Copyright>Copyright © Serilog Contributors 2017-2023</Copyright>
+        <Copyright>Copyright © Serilog Contributors 2017-2025</Copyright>
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -24,7 +24,9 @@
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' or 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' or 
+                          '$(TargetFramework)' == 'net8.0' or 
+                          '$(TargetFramework)' == 'net7.0' or 
                           '$(TargetFramework)' == 'net6.0' or 
                           '$(TargetFramework)' == 'net5.0' or 
                           '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -19,8 +19,8 @@
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>8.1.0</VersionPrefix>
-        <PackageVersion>8.1.0</PackageVersion>
+        <VersionPrefix>8.2.0</VersionPrefix>
+        <PackageVersion>8.2.0-pre1</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -20,7 +20,7 @@
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <VersionPrefix>8.2.0</VersionPrefix>
-        <PackageVersion>8.2.0-pre1</PackageVersion>
+        <PackageVersion>8.2.0</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -19,8 +19,8 @@
         <Description>Serilog event sink that writes to the Raygun service.</Description>
         <PackageReleaseNotes>https://github.com/MindscapeHQ/serilog-sinks-raygun/blob/master/CHANGE-LOG.md</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>7.6.0</VersionPrefix>
-        <PackageVersion>7.6.0-pre-1</PackageVersion>
+        <VersionPrefix>8.1.0</VersionPrefix>
+        <PackageVersion>8.1.0</PackageVersion>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunClientSink.cs
@@ -25,6 +25,7 @@ public class RaygunClientSink : ILogEventSink
 
     private readonly IFormatProvider? _formatProvider;
     private readonly IEnumerable<string> _tags;
+    private readonly string _tagsProperty;
 
     private readonly RaygunClientBase _raygunClient;
 
@@ -34,14 +35,17 @@ public class RaygunClientSink : ILogEventSink
     /// <param name="raygunClient">Instance of RaygunClient which should be passed in by resolving from a DI container or a static instance.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
+    /// <param name="tagsProperty">The property where additional tags are stored when emitting log events.</param>
     public RaygunClientSink(RaygunClientBase raygunClient,
         IFormatProvider? formatProvider = null,
-        IEnumerable<string>? tags = null
+        IEnumerable<string>? tags = null,
+        string tagsProperty = "Tags"
     )
     {
         _raygunClient = raygunClient;
         _formatProvider = formatProvider;
         _tags = tags ?? Array.Empty<string>();
+        _tagsProperty = tagsProperty;
         
         _raygunClient.CustomGroupingKey += OnCustomGroupingKey;
 
@@ -57,13 +61,21 @@ public class RaygunClientSink : ILogEventSink
     public void Emit(LogEvent logEvent)
     {
         // Include the log level as a tag.
-        var tags = _tags.Concat(new[] { logEvent.Level.ToString() }).ToList();
+        var tags = _tags.Concat([logEvent.Level.ToString()]).ToList();
         var properties = logEvent.Properties.ToDictionary(kv => kv.Key, kv => kv.Value);
 
         // Add the message and template to the properties
         properties[RenderedLogMessageProperty] = new ScalarValue(logEvent.RenderMessage(_formatProvider));
         properties[LogMessageTemplateProperty] = new ScalarValue(logEvent.MessageTemplate.Text);
         properties[OccurredProperty] = new ScalarValue(logEvent.Timestamp.UtcDateTime);
+        
+        // Add additional custom tags
+        if (properties.TryGetValue(_tagsProperty, out var eventTags) && eventTags is SequenceValue tagsSequence)
+        {
+            tags.AddRange(tagsSequence.Elements.Select(t => t.ToString("l", null)));
+
+            properties.Remove(_tagsProperty);
+        }
 
         // Decide what exception object to send
         var exception = logEvent.Exception ?? new NullException(GetCurrentExecutionStackTrace());


### PR DESCRIPTION
The `RaygunSink` implementation is able to extract tags from emitted log event properties, this PR implements that same behaviour in the `RaygunClientSink`.